### PR TITLE
add support for Joi.object(...).append(...)

### DIFF
--- a/index.spec.ts
+++ b/index.spec.ts
@@ -193,3 +193,18 @@ export const validationOverwrittenReturn: strictEnum = Joi.validate(
     if (typeof value === 'number') return 'tag' as 'tag';
   }
 );
+
+const appended_schema = jobOperatorRoleSchema.append({
+  appendedProp: Joi.boolean()
+})
+
+type extractAppendedSchema = Joi.extractType<typeof appended_schema>
+export const extractedAppended: extractAppendedSchema = {
+  id: '2015',
+  user_id: '102',
+  job_id: '52',
+  role: 'requester',
+  parent_index: 5,
+  pipeline_rules: [extractedRule],
+  appendedProp: true
+}

--- a/index.ts
+++ b/index.ts
@@ -246,6 +246,19 @@ declare module '@hapi/joi' {
           : ObjectSchema<Box<extractMap<{ [key: string]: T }>, false>>)
       : ObjectSchema<Box<extractMap<{ [key: string]: T }>, false>>;
 
+    append<T extends mappedSchemaMap|null|undefined>(
+      schema: T
+    ):
+      T extends mappedSchemaMap ?
+        (
+          this extends ObjectSchema<infer O>
+            ? (O extends Box<infer oT, infer oR>
+            ? ObjectSchema<BoxType<O, oT & extractMap<T>>>
+            : ObjectSchema<Box<extractMap<T>, false>>)
+            : ObjectSchema<Box<extractMap<T>, false>>
+        ) :
+        this
+
     // this extends ObjectSchema<infer O>
     //   ? (O extends null
     //       ? ObjectSchema<extractMap<{ [key: string]: T }>>


### PR DESCRIPTION
I had a case where `append` function were used in schema and type extractor was not aware of appended properties.