### PR TITLE
Feature/joi16

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -322,7 +322,6 @@ declare namespace JoiExtract {
     optional(): AlternativesSchema<BoxReq<N, false>>;
     optional(): this;
 
-    // TODO: this is the section that causes the type error
     when<
       R,
       T1 extends mappedSchema,
@@ -338,7 +337,7 @@ declare namespace JoiExtract {
             >
           : AlternativesSchema<Box<extractType<T['then']> | extractType<T['otherwise']>, false>>)
       : AlternativesSchema<Box<extractType<T['then']> | extractType<T['otherwise']>, false>>;
-    
+
     when(ref: string | Joi.Reference, options: Joi.WhenOptions): this;
     when(ref: Joi.Schema, options: Joi.WhenSchemaOptions): this;
   }

--- a/index.ts
+++ b/index.ts
@@ -1,6 +1,5 @@
 /** @format */
 
-import '@hapi/joi';
 import * as Joi from '@hapi/joi';
 
 /**

--- a/index.ts
+++ b/index.ts
@@ -55,10 +55,6 @@ declare namespace JoiExtract {
 
   export type extendsGuard<T, S> = S extends T ? S : T;
 
-  // interface ValidationResult<T> { }
-
-  // export interface AnySchema { }
-
   /**
    * Validation: extraction decorated methods
    */
@@ -326,6 +322,7 @@ declare namespace JoiExtract {
     optional(): AlternativesSchema<BoxReq<N, false>>;
     optional(): this;
 
+    // TODO: this is the section that causes the type error
     when<
       R,
       T1 extends mappedSchema,
@@ -385,18 +382,7 @@ declare namespace JoiExtract {
         /** Primitive types */
         T extends primitiveType ? T :
 
-        // debug, trying to understand why every schema is accepted within this extends clause
-        // T extends StringSchema<infer O> ? O :
-
         /** Holds the extracted type */
-        // T extends Joi.StringSchema ? string :
-        // T extends Joi.BooleanSchema ? boolean :
-        // T extends Joi.NumberSchema ? number :
-        // T extends Joi.DateSchema ? Date :
-        // T extends Joi.FunctionSchema ? Function :
-        // T extends Joi.ArraySchema ? any[] :
-        // T extends Joi.ObjectSchema ? { [k: string]: any } :
-
         T extends StringSchema<infer O> ? maybeExtractBox<O> :
         T extends BooleanSchema<infer O> ? maybeExtractBox<O> :
         T extends NumberSchema<infer O> ? maybeExtractBox<O> :

--- a/index.ts
+++ b/index.ts
@@ -1,14 +1,14 @@
 /** @format */
 
 import '@hapi/joi';
-import { SchemaLike } from '@hapi/joi';
+import * as Joi from '@hapi/joi';
 
 /**
  * Helpers
  */
 type Map<T> = { [P in keyof T]: T[P] };
 
-declare namespace Joi {
+declare namespace JoiExtract {
   /**
    * Field requirements interface
    */
@@ -48,41 +48,41 @@ declare namespace Joi {
 
   // Base types
   type primitiveType = string | number | boolean | Function | Date | undefined | null | void;
-  type thruthyPrimitiveType = NonNullable<primitiveType>;
+  type truthyPrimitiveType = NonNullable<primitiveType>;
 
-  export type mappedSchema = SchemaLike | BoxedPrimitive;
+  export type mappedSchema = Joi.SchemaLike | BoxedPrimitive;
   export type mappedSchemaMap<T = any> = { [K: string]: mappedSchema };
   // export type mappedSchemaMap<T extends mappedSchema = any> = { [K in keyof T]: T[K] };
 
   export type extendsGuard<T, S> = S extends T ? S : T;
 
-  interface ValidationResult<T> { }
+  // interface ValidationResult<T> { }
 
-  export interface AnySchema { }
+  // export interface AnySchema { }
 
   /**
    * Validation: extraction decorated methods
    */
-  // export function validate<T, S extends mappedSchemaMap>(
-  //   value: T,
-  //   schema: S
-  // ): ValidationResult<extendsGuard<T, extractType<S>>>;
-  // export function validate<T, S extends mappedSchemaMap>(
-  //   value: T,
-  //   schema: S,
-  //   options: ValidationOptions
-  // ): ValidationResult<extendsGuard<T, extractType<S>>>;
-  // export function validate<T, R, S extends mappedSchemaMap>(
-  //   value: T,
-  //   schema: S,
-  //   options: ValidationOptions,
-  //   callback: (err: ValidationError, value: extendsGuard<T, extractType<S>>) => R
-  // ): R;
-  // export function validate<T, R, S extends mappedSchemaMap>(
-  //   value: T,
-  //   schema: S,
-  //   callback: (err: ValidationError, value: extendsGuard<T, extractType<S>>) => R
-  // ): R;
+  export function validate<T, S extends mappedSchemaMap>(
+    value: T,
+    schema: S
+  ): Joi.ValidationResult;
+  export function validate<T, S extends mappedSchemaMap>(
+    value: T,
+    schema: S,
+    options: Joi.ValidationOptions
+  ): Joi.ValidationResult;
+  export function validate<T, R, S extends mappedSchemaMap>(
+    value: T,
+    schema: S,
+    options: Joi.ValidationOptions,
+    callback: (err: Joi.ValidationError, value: extendsGuard<T, extractType<S>>) => R
+  ): R;
+  export function validate<T, R, S extends mappedSchemaMap>(
+    value: T,
+    schema: S,
+    callback: (err: Joi.ValidationError, value: extendsGuard<T, extractType<S>>) => R
+  ): R;
 
   // TODO: concat
   // concat(schema: this): this;
@@ -113,6 +113,7 @@ declare namespace Joi {
     exist(): this;
     optional(): StringSchema<BoxReq<N, false>>;
     optional(): this;
+    __stringSchema(): void;
   }
 
   export function string<T extends string>(): StringSchema<{ T: extractType<T>; R: false }>;
@@ -136,6 +137,7 @@ declare namespace Joi {
     exist(): this;
     optional(): NumberSchema<BoxReq<N, false>>;
     optional(): this;
+    __numberSchema(): void;
   }
 
   export function number<T extends number>(): NumberSchema<Box<extractType<T>, false>>;
@@ -162,6 +164,7 @@ declare namespace Joi {
     exist(): this;
     optional(): BooleanSchema<BoxReq<N, false>>;
     optional(): this;
+    __booleanSchema(): void;
   }
 
   export function boolean<T extends boolean>(): BooleanSchema<Box<T, false>>;
@@ -185,6 +188,7 @@ declare namespace Joi {
     exist(): this;
     optional(): DateSchema<BoxReq<N, false>>;
     optional(): this;
+    __dateSchema(): void;
   }
 
   export function date<T extends Date>(): DateSchema<Box<T, false>>;
@@ -203,6 +207,7 @@ declare namespace Joi {
     exist(): this;
     optional(): FunctionSchema<BoxReq<N, false>>;
     optional(): this;
+    __functionSchema(): void;
   }
 
   export function func<T extends Function>(): FunctionSchema<Box<T, false>>;
@@ -232,7 +237,7 @@ declare namespace Joi {
   /**
    * Object: extraction decorated schema
    */
-  export interface ObjectSchema<N = null> extends AnySchema {
+  export interface ObjectSchema<N = null> extends Joi.AnySchema {
     keys<T extends mappedSchemaMap>(
       schema: T
     ): this extends ObjectSchema<infer O>
@@ -241,14 +246,14 @@ declare namespace Joi {
           : ObjectSchema<Box<extractMap<T>, false>>)
       : ObjectSchema<Box<extractMap<T>, false>>;
 
-    // pattern<S extends StringSchema, T extends mappedSchema>(
-    //   pattern: S,
-    //   schema: T
-    // ): this extends ObjectSchema<infer O>
-    //   ? (O extends Box<infer oT, infer oR>
-    //       ? ObjectSchema<BoxType<O, oT | extractMap<{ [key in extractType<S>]: T }>>>
-    //       : ObjectSchema<Box<extractMap<{ [key in extractType<S>]: T }>, false>>)
-    //   : ObjectSchema<Box<extractMap<{ [key in extractType<S>]: T }>, false>>;
+    pattern<S extends StringSchema, T extends mappedSchema>(
+      pattern: S,
+      schema: T
+    ): this extends ObjectSchema<infer O>
+      ? (O extends Box<infer oT, infer oR>
+          ? ObjectSchema<BoxType<O, oT | extractMap<{ [key in extractType<S>]: T }>>>
+          : ObjectSchema<Box<extractMap<{ [key in extractType<S>]: T }>, false>>)
+      : ObjectSchema<Box<extractMap<{ [key in extractType<S>]: T }>, false>>;
 
     pattern<T extends mappedSchema>(
       pattern: RegExp,
@@ -278,7 +283,7 @@ declare namespace Joi {
     //       : ObjectSchema<extractMap<{ [key: string]: T }> | O>)
     //   : ObjectSchema<extractMap<{ [key: string]: T }>>;
 
-    pattern(pattern: RegExp | SchemaLike, schema: SchemaLike): this;
+    pattern(pattern: RegExp | Joi.SchemaLike, schema: Joi.SchemaLike): this;
 
     required(): ObjectSchema<BoxReq<N, true>>;
     required(): this;
@@ -295,25 +300,25 @@ declare namespace Joi {
   /**
    * Alternatives: extraction decorated schema
    */
-  export interface AlternativesSchema<N = any> extends AnySchema {
-    // try<T extends mappedSchema[]>(
-    //   ...values: T
-    // ): this extends AlternativesSchema<infer O>
-    //   ? (O extends Box<infer oT, infer oR>
-    //       ? AlternativesSchema<BoxType<O, oT | extractType<T>>>
-    //       : AlternativesSchema<Box<extractType<T>, false>>)
-    //   : AlternativesSchema<Box<extractType<T>, false>>;
+  export interface AlternativesSchema<N = any> extends Joi.AnySchema {
+    try<T extends mappedSchema[]>(
+      ...values: T
+    ): this extends AlternativesSchema<infer O>
+      ? (O extends Box<infer oT, infer oR>
+          ? AlternativesSchema<BoxType<O, oT | extractType<T>>>
+          : AlternativesSchema<Box<extractType<T>, false>>)
+      : AlternativesSchema<Box<extractType<T>, false>>;
 
-    // try<T extends mappedSchema[]>(
-    //   values: T
-    // ): this extends AlternativesSchema<infer O>
-    //   ? (O extends Box<infer oT, infer oR>
-    //       ? AlternativesSchema<BoxType<O, oT | extractType<T>>>
-    //       : AlternativesSchema<Box<extractType<T>, false>>)
-    //   : AlternativesSchema<Box<extractType<T>, false>>;
+    try<T extends mappedSchema[]>(
+      values: T
+    ): this extends AlternativesSchema<infer O>
+      ? (O extends Box<infer oT, infer oR>
+          ? AlternativesSchema<BoxType<O, oT | extractType<T>>>
+          : AlternativesSchema<Box<extractType<T>, false>>)
+      : AlternativesSchema<Box<extractType<T>, false>>;
 
-    try(...types: SchemaLike[]): this;
-    try(types: SchemaLike[]): this;
+    try(...types: Joi.SchemaLike[]): this;
+    try(types: Joi.SchemaLike[]): this;
 
     required(): AlternativesSchema<BoxReq<N, true>>;
     required(): this;
@@ -382,7 +387,7 @@ declare namespace Joi {
         T extends primitiveType ? T :
 
         // debug, trying to understand why every schema is accepted within this extends clause
-        T extends StringSchema<infer O> ? O :
+        // T extends StringSchema<infer O> ? O :
 
         /** Holds the extracted type */
         // T extends Joi.StringSchema ? string :
@@ -392,7 +397,7 @@ declare namespace Joi {
         // T extends Joi.FunctionSchema ? Function :
         // T extends Joi.ArraySchema ? any[] :
         // T extends Joi.ObjectSchema ? { [k: string]: any } :
-        
+
         T extends StringSchema<infer O> ? maybeExtractBox<O> :
         T extends BooleanSchema<infer O> ? maybeExtractBox<O> :
         T extends NumberSchema<infer O> ? maybeExtractBox<O> :
@@ -404,7 +409,7 @@ declare namespace Joi {
         /** Supports Joi.alternatives(Schema1, schema2, ...) */
         T extends AlternativesSchema<infer O> ? maybeExtractBox<O> :
         T extends mappedSchemaMap<infer O> ? maybeExtractBox<O> :
-        T extends AnySchema ? any :
+        T extends Joi.AnySchema ? any :
         any;
 
   // prettier-ignore
@@ -440,4 +445,4 @@ declare namespace Joi {
         extractOne<T>;
 }
 
-export type extractType<T extends Joi.mappedSchema> = Joi.extractType<T>
+export type extractType<T extends JoiExtract.mappedSchema> = JoiExtract.extractType<T>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,49 +1,58 @@
 {
   "name": "joi-extract-type",
-  "version": "15.0.0",
+  "version": "16.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "@hapi/address": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@hapi/address/-/address-2.0.0.tgz",
-      "integrity": "sha512-mV6T0IYqb0xL1UALPFplXYQmR0twnXG0M6jUswpquqT2sD12BOiCiLy3EvMp/Fy7s3DZElC4/aPjEjo2jeZpvw=="
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@hapi/address/-/address-2.1.4.tgz",
+      "integrity": "sha512-QD1PhQk+s31P1ixsX0H0Suoupp3VMXzIVMSwobR3F3MSUO2YCV0B7xqLcUw/Bh8yuvd3LhpyqLQWTNcRmp6IdQ=="
+    },
+    "@hapi/formula": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@hapi/formula/-/formula-1.2.0.tgz",
+      "integrity": "sha512-UFbtbGPjstz0eWHb+ga/GM3Z9EzqKXFWIbSOFURU0A/Gku0Bky4bCk9/h//K2Xr3IrCfjFNhMm4jyZ5dbCewGA=="
     },
     "@hapi/hoek": {
-      "version": "6.2.4",
-      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-6.2.4.tgz",
-      "integrity": "sha512-HOJ20Kc93DkDVvjwHyHawPwPkX44sIrbXazAUDiUXaY2R9JwQGo2PhFfnQtdrsIe4igjG2fPgMra7NYw7qhy0A=="
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.5.0.tgz",
+      "integrity": "sha512-7XYT10CZfPsH7j9F1Jmg1+d0ezOux2oM2GfArAzLwWe4mE2Dr3hVjsAL6+TFY49RRJlCdJDMw3nJsLFroTc8Kw=="
     },
     "@hapi/joi": {
-      "version": "15.0.3",
-      "resolved": "https://registry.npmjs.org/@hapi/joi/-/joi-15.0.3.tgz",
-      "integrity": "sha512-z6CesJ2YBwgVCi+ci8SI8zixoj8bGFn/vZb9MBPbSyoxsS2PnWYjHcyTM17VLK6tx64YVK38SDIh10hJypB+ig==",
+      "version": "16.1.8",
+      "resolved": "https://registry.npmjs.org/@hapi/joi/-/joi-16.1.8.tgz",
+      "integrity": "sha512-wAsVvTPe+FwSrsAurNt5vkg3zo+TblvC5Bb1zMVK6SJzZqw9UrJnexxR+76cpePmtUZKHAPxcQ2Bf7oVHyahhg==",
       "requires": {
-        "@hapi/address": "2.x.x",
-        "@hapi/hoek": "6.x.x",
-        "@hapi/topo": "3.x.x"
+        "@hapi/address": "^2.1.2",
+        "@hapi/formula": "^1.2.0",
+        "@hapi/hoek": "^8.2.4",
+        "@hapi/pinpoint": "^1.0.2",
+        "@hapi/topo": "^3.1.3"
       }
     },
+    "@hapi/pinpoint": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@hapi/pinpoint/-/pinpoint-1.0.2.tgz",
+      "integrity": "sha512-dtXC/WkZBfC5vxscazuiJ6iq4j9oNx1SHknmIr8hofarpKUZKmlUVYVIhNVzIEgK5Wrc4GMHL5lZtt1uS2flmQ=="
+    },
     "@hapi/topo": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-3.1.0.tgz",
-      "integrity": "sha512-gZDI/eXOIk8kP2PkUKjWu9RW8GGVd2Hkgjxyr/S7Z+JF+0mr7bAlbw+DkTRxnD580o8Kqxlnba9wvqp5aOHBww==",
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-3.1.6.tgz",
+      "integrity": "sha512-tAag0jEcjwH+P2quUfipd7liWCNX2F8NvYjQp2wtInsZxnMlypdw0FtAOLxtvvkO+GSRRbmNi8m/5y42PQJYCQ==",
       "requires": {
-        "@hapi/hoek": "6.x.x"
+        "@hapi/hoek": "^8.3.0"
       }
     },
     "@types/hapi__joi": {
-      "version": "15.0.1",
-      "resolved": "https://registry.npmjs.org/@types/hapi__joi/-/hapi__joi-15.0.1.tgz",
-      "integrity": "sha512-uqH3kTO1nrhe+Pbq+dQKrulrfscRPjFZNv9UWA3FupJZBHw+miT7yiV6C8A80YLnn0o6zbgTProncBb3d7QohA==",
-      "requires": {
-        "@types/hapi__joi": "*"
-      }
+      "version": "16.0.8",
+      "resolved": "https://registry.npmjs.org/@types/hapi__joi/-/hapi__joi-16.0.8.tgz",
+      "integrity": "sha512-13I2m/eIoKF8JwLkeibJjsu2EKui18Vug7cOtzuUbWtF7mHyBgFCzSxnthHQ77z9S3T68ZldsGZpK1qXbinQjw=="
     },
     "typescript": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.2.2.tgz",
-      "integrity": "sha512-VCj5UiSyHBjwfYacmDuc/NOk4QQixbE+Wn7MFJuS0nRuPQbof132Pw4u53dm264O8LPc2MVsc7RJNml5szurkg==",
+      "version": "3.7.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.7.5.tgz",
+      "integrity": "sha512-/P5lkRXkWHNAbcJIiHPfRoKqyd7bsyCma1hZNUGfn20qm64T6ZBlrzprymeu918H+mB/0rIg2gGK/BXkhhYgBw==",
       "dev": true
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "joi-extract-type",
-  "version": "15.0.1",
+  "version": "16.0.0",
   "description": "Provides native type extraction from Joi schemas for Typescript",
   "main": "dist/index.js",
   "scripts": {
@@ -27,7 +27,7 @@
     "typescript": "^3.2.2"
   },
   "peerDependencies": {
-    "@hapi/joi": ">=15"
+    "@hapi/joi": ">=16"
   },
   "dependencies": {
     "@hapi/joi": "16",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "typescript": "^3.2.2"
   },
   "peerDependencies": {
-    "@hapi/joi": ">=16"
+    "@hapi/joi": "16"
   },
   "dependencies": {
     "@hapi/joi": "16",


### PR DESCRIPTION
We are attempting to solve [Issue 22](https://github.com/TCMiranda/joi-extract-type/issues/22) and I think we're close. There are a few changes including:

1. Moving out of the Joi namespace to avoid collisions
2. Terminating types with methods like `__stringSchema` to keep them distinct

This is the remaining error:
```
$ tsc
index.ts:302:20 - error TS2430: Interface 'AlternativesSchema<N>' incorrectly extends interface 'AnySchema<any>'.
  The types returned by 'when(...)' are incompatible between these types.
    Type 'this extends AlternativesSchema<infer O> ? O extends Box<infer oT, infer oR> ? AlternativesSchema<BoxType<O, any>> : AlternativesSchema<Box<any, false>> : AlternativesSchema<...>' is not assignable to type 'this'.
      Type 'AlternativesSchema<Box<any, false>>' is not assignable to type 'this'.
        Type 'N extends Box<infer oT, infer oR> ? AlternativesSchema<BoxType<N, any>> : AlternativesSchema<Box<any, false>>' is not assignable to type 'this'.
          Type 'AlternativesSchema<Box<any, false>> | AlternativesSchema<BoxType<N, any>>' is not assignable to type 'this'.
            Type 'AlternativesSchema<Box<any, false>>' is not assignable to type 'this'.

302   export interface AlternativesSchema<N = any> extends Joi.AnySchema {
```
This is isolated because commenting the `when` section has no other tsc issues.
Can someone help with this typescript error?