### PR TITLE
Fix `extractType` type in TypeScript 3.9.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "joi-extract-type",
-  "version": "15.0.0",
+  "version": "15.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -41,9 +41,9 @@
       }
     },
     "typescript": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.2.2.tgz",
-      "integrity": "sha512-VCj5UiSyHBjwfYacmDuc/NOk4QQixbE+Wn7MFJuS0nRuPQbof132Pw4u53dm264O8LPc2MVsc7RJNml5szurkg==",
+      "version": "3.9.6",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.6.tgz",
+      "integrity": "sha512-Pspx3oKAPJtjNwE92YS05HQoY7z2SFyOpHo9MqJor3BXAGNaPUs83CuVp9VISFkSjyRfiTpmKuAYGJB7S7hOxw==",
       "dev": true
     }
   }

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "homepage": "https://github.com/TCMiranda/joi-extract-type#readme",
   "devDependencies": {
-    "typescript": "^3.2.2"
+    "typescript": "^3.9.6"
   },
   "peerDependencies": {
     "@hapi/joi": "~15"


### PR DESCRIPTION
`extractType` is currently displays the following error with TypeScript 3.9.x:

> error TS2456: Type alias 'extractType' circularly references itself.

From the TypeScript team [^1]:

> Certain things can be deferred if there's a different declaration to "pause" the circularity at. I don't want to commit any specific circular behavior to bug/not bug; it depends on a lot of different factors and is sensitive to exactly where TS tries to resolve certain conditionals.

So basically, this PR keeps the same behavior as before, but uses a workaround to prevent the TypeScript 3.9.6 compiler from getting into a `circularly references` error state.

Fixes https://github.com/TCMiranda/joi-extract-type/issues/33

[^1]: https://github.com/microsoft/TypeScript/issues/39147#issuecomment-646120321
