### PR TITLE
Support sideway/joi

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,4 @@ typings/
 
 *.js
 .vscode
+.idea

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # joi-extract-type
 
-Provides native type extraction from [Joi](https://github.com/hapijs/joi) Schemas for Typescript.
+Provides native type extraction from [Joi](https://github.com/sideway/joi) Schemas for Typescript.
 
 ---
 
@@ -13,7 +13,7 @@ This library enhances Joi interfaces to provides an utility to infer the type fr
 **Why should you use it**
 
 - Avoid duplication from Joi Schemas and application interfaces
-- Port javascript applications using [Joi](https://github.com/hapijs/joi) to typescript easily
+- Port javascript applications using [Joi](https://github.com/sideway/joi) to typescript easily
 - Does not requires changes to already defined Schemas
 
 **Limitation**
@@ -40,15 +40,15 @@ npm i --save joi-extract-type@ts2-1
 Import the library and patch Joi's typings:
 
 ```ts
-import * as Joi from '@hapi/joi';
-import JoiExtractType from 'joi-extract-type';
+import Joi from 'joi';
+import extractType from 'joi-extract-type';
 ```
 
-Create the schemas and use `Joi.extractType` to infer the type:
+Create the schemas and use `extractType` to infer the type:
 
 ```ts
 const is_enabled = Joi.boolean();
-type extractBoolean = JoiExtractType.extractType<typeof is_enabled>;
+type extractBoolean = extractType<typeof is_enabled>;
 export const extractedBoolean: extractBoolean = true;
 ```
 
@@ -58,30 +58,30 @@ The following code is copied from this library spec, which compiles the code wit
 
 ```ts
 const is_enabled = Joi.boolean();
-type extractBoolean = JoiExtractType.extractType<typeof is_enabled>;
+type extractBoolean = extractType<typeof is_enabled>;
 export const extractedBoolean: extractBoolean = true;
 
 const full_name = Joi.string();
-type extractString = JoiExtractType.extractType<typeof full_name>;
+type extractString = extractType<typeof full_name>;
 export const extractedString: extractString = 'string';
 
 const user = Joi.object({ full_name, is_enabled });
-type extractObject = JoiExtractType.extractType<typeof user>;
+type extractObject = extractType<typeof user>;
 export const extractedObject: extractObject = {
   full_name: extractedString,
   is_enabled: extractedBoolean,
 };
 
 const roles = Joi.array().items(Joi.string());
-type extractArray = JoiExtractType.extractType<typeof roles>;
+type extractArray = extractType<typeof roles>;
 export const extractedArray: extractArray = ['admin'];
 
 const apply = Joi.array().items(Joi.object({ id: Joi.string() }));
-type extractApply = JoiExtractType.extractType<typeof apply>;
+type extractApply = extractType<typeof apply>;
 export const extractedApply: extractApply = [{ id: '3' }, { id: '4' }];
 
 const rule = Joi.object({ apply });
-type extractRule = JoiExtractType.extractType<typeof rule>;
+type extractRule = extractType<typeof rule>;
 export const extractedRule: extractRule = { apply: extractedApply };
 
 export const jobOperatorRoleSchema = Joi.object({
@@ -91,7 +91,7 @@ export const jobOperatorRoleSchema = Joi.object({
   role: Joi.string().valid(['recruiter', 'requester']),
   pipeline_rules: Joi.array().items(rule),
 });
-type extractComplexType = JoiExtractType.extractType<typeof jobOperatorRoleSchema>;
+type extractComplexType = extractType<typeof jobOperatorRoleSchema>;
 export const extractedComplexType: extractComplexType = {
   id: '2015',
   user_id: '102',

--- a/README.md
+++ b/README.md
@@ -41,14 +41,14 @@ Import the library and patch Joi's typings:
 
 ```ts
 import * as Joi from '@hapi/joi';
-import 'joi-extract-type';
+import JoiExtractType from 'joi-extract-type';
 ```
 
 Create the schemas and use `Joi.extractType` to infer the type:
 
 ```ts
 const is_enabled = Joi.boolean();
-type extractBoolean = Joi.extractType<typeof is_enabled>;
+type extractBoolean = JoiExtractType.extractType<typeof is_enabled>;
 export const extractedBoolean: extractBoolean = true;
 ```
 
@@ -58,30 +58,30 @@ The following code is copied from this library spec, which compiles the code wit
 
 ```ts
 const is_enabled = Joi.boolean();
-type extractBoolean = Joi.extractType<typeof is_enabled>;
+type extractBoolean = JoiExtractType.extractType<typeof is_enabled>;
 export const extractedBoolean: extractBoolean = true;
 
 const full_name = Joi.string();
-type extractString = Joi.extractType<typeof full_name>;
+type extractString = JoiExtractType.extractType<typeof full_name>;
 export const extractedString: extractString = 'string';
 
 const user = Joi.object({ full_name, is_enabled });
-type extractObject = Joi.extractType<typeof user>;
+type extractObject = JoiExtractType.extractType<typeof user>;
 export const extractedObject: extractObject = {
   full_name: extractedString,
   is_enabled: extractedBoolean,
 };
 
 const roles = Joi.array().items(Joi.string());
-type extractArray = Joi.extractType<typeof roles>;
+type extractArray = JoiExtractType.extractType<typeof roles>;
 export const extractedArray: extractArray = ['admin'];
 
 const apply = Joi.array().items(Joi.object({ id: Joi.string() }));
-type extractApply = Joi.extractType<typeof apply>;
+type extractApply = JoiExtractType.extractType<typeof apply>;
 export const extractedApply: extractApply = [{ id: '3' }, { id: '4' }];
 
 const rule = Joi.object({ apply });
-type extractRule = Joi.extractType<typeof rule>;
+type extractRule = JoiExtractType.extractType<typeof rule>;
 export const extractedRule: extractRule = { apply: extractedApply };
 
 export const jobOperatorRoleSchema = Joi.object({
@@ -91,7 +91,7 @@ export const jobOperatorRoleSchema = Joi.object({
   role: Joi.string().valid(['recruiter', 'requester']),
   pipeline_rules: Joi.array().items(rule),
 });
-type extractComplexType = Joi.extractType<typeof jobOperatorRoleSchema>;
+type extractComplexType = JoiExtractType.extractType<typeof jobOperatorRoleSchema>;
 export const extractedComplexType: extractComplexType = {
   id: '2015',
   user_id: '102',
@@ -101,7 +101,7 @@ export const extractedComplexType: extractComplexType = {
 };
 
 // typeof extractedComplexType
-// const extractedComplexType: Joi.extractMap<{
+// const extractedComplexType: JoiExtractType.extractMap<{
 //     id: Joi.StringSchema;
 //     user_id: Joi.StringSchema;
 //     job_id: Joi.StringSchema;

--- a/index.spec.ts
+++ b/index.spec.ts
@@ -1,29 +1,29 @@
 /** @format */
 
 import * as Joi from 'joi';
-import JoiExtractType from './index';
+import extractType, { extendsGuard } from './index';
 
 const extJoi = Joi.extend({} as Joi.Extension);
 
 // Unknown types or AnySchema defaults to type any
 const any_schema = Joi.any();
-type extractAny = JoiExtractType.extractType<typeof any_schema>;
+type extractAny = extractType<typeof any_schema>;
 export const extractedAny: extractAny = 'anything';
 
 const is_enabled = Joi.boolean();
-type extractBoolean = JoiExtractType.extractType<typeof is_enabled>;
+type extractBoolean = extractType<typeof is_enabled>;
 export const extractedBoolean: extractBoolean = true;
 
 const full_name = extJoi.string();
-type extractString = JoiExtractType.extractType<typeof full_name>;
+type extractString = extractType<typeof full_name>;
 export const extractedString: extractString = 'string';
 
 const created_at = Joi.date();
-type extractDate = JoiExtractType.extractType<typeof created_at>;
+type extractDate = extractType<typeof created_at>;
 export const extractedDate: extractDate = new Date();
 
 const priority = extJoi.number();
-type extractNumber = JoiExtractType.extractType<typeof priority>;
+type extractNumber = extractType<typeof priority>;
 export const extractedNumber: extractNumber = 5;
 
 const userAsObject = {
@@ -35,8 +35,8 @@ const userAsObject = {
   priority,
 };
 const user = Joi.object(userAsObject);
-type extractObject = JoiExtractType.extractType<typeof userAsObject>;
-type extractObjectSchema = JoiExtractType.extractType<typeof user>;
+type extractObject = extractType<typeof userAsObject>;
+type extractObjectSchema = extractType<typeof user>;
 export const extractedObject: extractObject = {
   created_at: extractedDate,
   full_name: extractedString,
@@ -50,17 +50,17 @@ const roles = extJoi
   .array()
   .items(extJoi.string().valid(['admin', 'member', 'guest']))
   .items(extJoi.number());
-type extractArray = JoiExtractType.extractType<typeof roles>;
+type extractArray = extractType<typeof roles>;
 export const extractedArray: extractArray = ['admin', 2];
 
 const uuid_exp = `[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}`;
 const uuid_pattern = new RegExp(uuid_exp, 'i');
 const uuid = extJoi.string().regex(uuid_pattern);
-type extractUuid = JoiExtractType.extractType<typeof uuid>;
+type extractUuid = extractType<typeof uuid>;
 export const extractedUuid: extractUuid = '123e4567-e89b-12d3-a456-426655440000';
 
 const apply = extJoi.array().items(Joi.object({ id: uuid.required() }));
-type extractApply = JoiExtractType.extractType<typeof apply>;
+type extractApply = extractType<typeof apply>;
 const anyApply = [{ id: '3' }, { id: undefined }];
 export const extractedApply: extractApply = anyApply;
 
@@ -68,18 +68,18 @@ const rule_flat = extJoi
   .array()
   .items(extJoi.string())
   .items(Joi.object({ id: uuid.required() }));
-type extractRuleFlat = JoiExtractType.extractType<typeof rule_flat>;
+type extractRuleFlat = extractType<typeof rule_flat>;
 export const extractedRuleFlat: extractRuleFlat = [{ id: 'string' }, 'test'];
 
 const rule = Joi.object().keys({ apply, id: uuid.required() });
-type extractRule = JoiExtractType.extractType<typeof rule>;
+type extractRule = extractType<typeof rule>;
 export const extractedRule: extractRule = {
   apply: extractedApply,
   id: 'string',
 };
 
 export const ruleMap = Joi.object().pattern(/\w+/, rule);
-type extractRuleMap = JoiExtractType.extractType<typeof ruleMap>;
+type extractRuleMap = extractType<typeof ruleMap>;
 export const extractedRuleMap: extractRuleMap = { somekey: extractedRule };
 
 export const jobOperatorRoleSchema = Joi.object({
@@ -91,7 +91,7 @@ export const jobOperatorRoleSchema = Joi.object({
   role: extJoi.string().valid('recruiter', 'requester'),
   pipeline_rules: extJoi.array().items(rule).required(),
 });
-type extractComplexType = JoiExtractType.extractType<typeof jobOperatorRoleSchema>;
+type extractComplexType = extractType<typeof jobOperatorRoleSchema>;
 export const extractedComplexType: extractComplexType = {
   id: '2015',
   user_id: '102',
@@ -111,7 +111,7 @@ export const usingDefaultWithProps = Joi.object({
     string: extJoi.string(),
   }),
 });
-type usingDefaultWithPropsType = JoiExtractType.extractType<typeof usingDefaultWithProps>;
+type usingDefaultWithPropsType = extractType<typeof usingDefaultWithProps>;
 export const extractedUsingDefaultWithProps: usingDefaultWithPropsType = {
   number_prop_with_default: 20,
   string_prop_with_default: 'string',
@@ -127,7 +127,7 @@ const appendedJobOperatorRoleSchema = jobOperatorRoleSchema.append({
   excluded: Joi.boolean(),
 });
 
-type extractAppendedSchema = JoiExtractType.extractType<typeof appendedJobOperatorRoleSchema>;
+type extractAppendedSchema = extractType<typeof appendedJobOperatorRoleSchema>;
 export const extractedAppended: extractAppendedSchema = {
   ...extractedComplexType,
   excluded: true,
@@ -137,22 +137,22 @@ function someFunction() {
   return someFunction;
 }
 const createUserSchema = Joi.func();
-type extractFunction = JoiExtractType.extractType<typeof createUserSchema>;
+type extractFunction = extractType<typeof createUserSchema>;
 export const extractedFunction: extractFunction = someFunction;
 
 const number_string = Joi.alt().try(extJoi.number().valid(1, 2, 3), extJoi.string());
-type extractNumberString = JoiExtractType.extractType<typeof number_string>;
+type extractNumberString = extractType<typeof number_string>;
 export const extractNumberStringNumber: extractNumberString = 2;
 export const extractNumberStringString: extractNumberString = '2';
 
 const date_time1 = Joi.alternatives([Joi.date(), extJoi.number(), extJoi.string()]);
-type extractDateTime1 = JoiExtractType.extractType<typeof date_time1>;
+type extractDateTime1 = extractType<typeof date_time1>;
 export const extractDateTimeDate1: extractDateTime1 = new Date();
 export const extractDateTimeTime1: extractDateTime1 = +new Date();
 export const extractDateTimeString1: extractDateTime1 = new Date().toISOString();
 
 const when = Joi.alt().when('x', { is: 'a', then: extJoi.string(), otherwise: extJoi.number() });
-type extractedWhen = JoiExtractType.extractType<typeof when>;
+type extractedWhen = extractType<typeof when>;
 export const extractWhen1: extractedWhen = 2;
 export const extractWhen2: extractedWhen = '2';
 
@@ -163,7 +163,7 @@ const required_alt = Joi.object({
     value: when.required(),
   }).required(),
 });
-type extractedRequiredAlt = JoiExtractType.extractType<typeof required_alt>;
+type extractedRequiredAlt = extractType<typeof required_alt>;
 export const extractRequiredAlt: extractedRequiredAlt = {
   required: { start_date: new Date(), value: '2' },
 };
@@ -177,7 +177,7 @@ const required_alt_augmented = required_alt.keys({
     .pattern(extJoi.string(), extJoi.number())
     .pattern(extJoi.string().valid('pattern_key'), extJoi.number()),
 });
-type extractedRequiredAltAugmented = JoiExtractType.extractType<typeof required_alt_augmented>;
+type extractedRequiredAltAugmented = extractType<typeof required_alt_augmented>;
 export const extractRequiredAltAugmented: extractedRequiredAltAugmented = {
   required: {
     start_date: new Date(),
@@ -190,15 +190,15 @@ const string_array_schema = [
   extJoi.string().default('test' as 'test'),
   extJoi.array().items([extJoi.string(), extJoi.number()]).valid('string', 2), // TODO overwrite valid on ArraySchema
 ];
-type extractStringArray = JoiExtractType.extractType<typeof string_array_schema>;
+type extractStringArray = extractType<typeof string_array_schema>;
 export const extractStringArrayString: extractStringArray = 'string';
 export const extractStringArrayArray: extractStringArray = ['string', 2];
 
 // A extends B type guard
-type numberExtendsAny = JoiExtractType.extendsGuard<any, extractNumber>;
+type numberExtendsAny = extendsGuard<any, extractNumber>;
 export const asNumber: numberExtendsAny = 2;
 
-type stringNotNumber = JoiExtractType.extendsGuard<string, extractNumber>;
+type stringNotNumber = extendsGuard<string, extractNumber>;
 export const asString: stringNotNumber = 'string';
 
 // Validation methods
@@ -222,7 +222,7 @@ export const validationOverwrittenReturn: strictEnum = priority.validate(
 );
 
 const nullableString = extJoi.string().valid('string').allow(null, 0);
-type extractNullableString = JoiExtractType.extractType<typeof nullableString>;
+type extractNullableString = extractType<typeof nullableString>;
 export const extractedNullableStringNull: extractNullableString = null;
 export const extractedNullableStringZero: extractNullableString = 0;
 export const extractedNullableString: extractNullableString = 'string';
@@ -231,7 +231,7 @@ const nullableNumber = extJoi
   .number()
   .allow(null as null)
   .default(5);
-type extractNullableNumber = JoiExtractType.extractType<typeof nullableNumber>;
+type extractNullableNumber = extractType<typeof nullableNumber>;
 export const extractedNullableNumberNull: extractNullableNumber = null;
 export const extractedNullableNumber: extractNullableNumber = 15;
 
@@ -246,7 +246,7 @@ const allNullable = {
   nullableObject: Joi.object({ nullableString }).allow(nullType),
   nullableAlt: Joi.alt(nullableString, nullableNumber).allow(nullType),
 };
-type extractAllNullable = JoiExtractType.extractType<typeof allNullable>;
+type extractAllNullable = extractType<typeof allNullable>;
 export const extractedAllNullable: extractAllNullable = {
   nullableString: null,
   nullableNumber: null,
@@ -261,7 +261,7 @@ export const extractedAllNullable: extractAllNullable = {
 export const anyRequired = Joi.any().required();
 export const anyOptional = Joi.any();
 export const anyTestSchema = { anyRequired, anyOptional };
-type extractedAnyTest = JoiExtractType.extractType<typeof anyTestSchema>;
+type extractedAnyTest = extractType<typeof anyTestSchema>;
 
 export let anyTests: extractedAnyTest;
 anyTests = { anyRequired: 'test', anyOptional: 'test' };
@@ -280,7 +280,7 @@ const nestedObjSchema = Joi.object()
     }),
   });
 
-type extractNestedObjSchema = JoiExtractType.extractType<typeof nestedObjSchema>;
+type extractNestedObjSchema = extractType<typeof nestedObjSchema>;
 export const extractedNestedObjSchema: extractNestedObjSchema = {
   nested: {
     foo: 'string',

--- a/index.spec.ts
+++ b/index.spec.ts
@@ -1,29 +1,29 @@
 /** @format */
 
-import * as Joi from '@hapi/joi';
-import './index';
+import * as Joi from 'joi';
+import JoiExtractType from './index';
 
 const extJoi = Joi.extend({} as Joi.Extension);
 
 // Unknown types or AnySchema defaults to type any
 const any_schema = Joi.any();
-type extractAny = Joi.extractType<typeof any_schema>;
+type extractAny = JoiExtractType.extractType<typeof any_schema>;
 export const extractedAny: extractAny = 'anything';
 
 const is_enabled = Joi.boolean();
-type extractBoolean = Joi.extractType<typeof is_enabled>;
+type extractBoolean = JoiExtractType.extractType<typeof is_enabled>;
 export const extractedBoolean: extractBoolean = true;
 
 const full_name = extJoi.string();
-type extractString = Joi.extractType<typeof full_name>;
+type extractString = JoiExtractType.extractType<typeof full_name>;
 export const extractedString: extractString = 'string';
 
 const created_at = Joi.date();
-type extractDate = Joi.extractType<typeof created_at>;
+type extractDate = JoiExtractType.extractType<typeof created_at>;
 export const extractedDate: extractDate = new Date();
 
 const priority = extJoi.number();
-type extractNumber = Joi.extractType<typeof priority>;
+type extractNumber = JoiExtractType.extractType<typeof priority>;
 export const extractedNumber: extractNumber = 5;
 
 const userAsObject = {
@@ -35,8 +35,8 @@ const userAsObject = {
   priority,
 };
 const user = Joi.object(userAsObject);
-type extractObject = Joi.extractType<typeof userAsObject>;
-type extractObjectSchema = Joi.extractType<typeof user>;
+type extractObject = JoiExtractType.extractType<typeof userAsObject>;
+type extractObjectSchema = JoiExtractType.extractType<typeof user>;
 export const extractedObject: extractObject = {
   created_at: extractedDate,
   full_name: extractedString,
@@ -50,17 +50,17 @@ const roles = extJoi
   .array()
   .items(extJoi.string().valid(['admin', 'member', 'guest']))
   .items(extJoi.number());
-type extractArray = Joi.extractType<typeof roles>;
-export const extactedArray: extractArray = ['admin', 2];
+type extractArray = JoiExtractType.extractType<typeof roles>;
+export const extractedArray: extractArray = ['admin', 2];
 
 const uuid_exp = `[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}`;
 const uuid_pattern = new RegExp(uuid_exp, 'i');
 const uuid = extJoi.string().regex(uuid_pattern);
-type extractUuid = Joi.extractType<typeof uuid>;
+type extractUuid = JoiExtractType.extractType<typeof uuid>;
 export const extractedUuid: extractUuid = '123e4567-e89b-12d3-a456-426655440000';
 
 const apply = extJoi.array().items(Joi.object({ id: uuid.required() }));
-type extractApply = Joi.extractType<typeof apply>;
+type extractApply = JoiExtractType.extractType<typeof apply>;
 const anyApply = [{ id: '3' }, { id: undefined }];
 export const extractedApply: extractApply = anyApply;
 
@@ -68,18 +68,18 @@ const rule_flat = extJoi
   .array()
   .items(extJoi.string())
   .items(Joi.object({ id: uuid.required() }));
-type extractRuleFlat = Joi.extractType<typeof rule_flat>;
+type extractRuleFlat = JoiExtractType.extractType<typeof rule_flat>;
 export const extractedRuleFlat: extractRuleFlat = [{ id: 'string' }, 'test'];
 
 const rule = Joi.object().keys({ apply, id: uuid.required() });
-type extractRule = Joi.extractType<typeof rule>;
+type extractRule = JoiExtractType.extractType<typeof rule>;
 export const extractedRule: extractRule = {
   apply: extractedApply,
   id: 'string',
 };
 
 export const ruleMap = Joi.object().pattern(/\w+/, rule);
-type extractRuleMap = Joi.extractType<typeof ruleMap>;
+type extractRuleMap = JoiExtractType.extractType<typeof ruleMap>;
 export const extractedRuleMap: extractRuleMap = { somekey: extractedRule };
 
 export const jobOperatorRoleSchema = Joi.object({
@@ -91,7 +91,7 @@ export const jobOperatorRoleSchema = Joi.object({
   role: extJoi.string().valid('recruiter', 'requester'),
   pipeline_rules: extJoi.array().items(rule).required(),
 });
-type extractComplexType = Joi.extractType<typeof jobOperatorRoleSchema>;
+type extractComplexType = JoiExtractType.extractType<typeof jobOperatorRoleSchema>;
 export const extractedComplexType: extractComplexType = {
   id: '2015',
   user_id: '102',
@@ -111,7 +111,7 @@ export const usingDefaultWithProps = Joi.object({
     string: extJoi.string(),
   }),
 });
-type usingDefaultWithPropsType = Joi.extractType<typeof usingDefaultWithProps>;
+type usingDefaultWithPropsType = JoiExtractType.extractType<typeof usingDefaultWithProps>;
 export const extractedUsingDefaultWithProps: usingDefaultWithPropsType = {
   number_prop_with_default: 20,
   string_prop_with_default: 'string',
@@ -121,13 +121,13 @@ export const extractedUsingDefaultWithProps: usingDefaultWithPropsType = {
   object_prop_with_default: { number: 5 },
 };
 
-export const extractedComplexTypeValidationResponse = Joi.validate({}, jobOperatorRoleSchema);
+export const extractedComplexTypeValidationResponse = jobOperatorRoleSchema.validate({});
 
 const appendedJobOperatorRoleSchema = jobOperatorRoleSchema.append({
   excluded: Joi.boolean(),
 });
 
-type extractAppendedSchema = Joi.extractType<typeof appendedJobOperatorRoleSchema>;
+type extractAppendedSchema = JoiExtractType.extractType<typeof appendedJobOperatorRoleSchema>;
 export const extractedAppended: extractAppendedSchema = {
   ...extractedComplexType,
   excluded: true,
@@ -136,23 +136,23 @@ export const extractedAppended: extractAppendedSchema = {
 function someFunction() {
   return someFunction;
 }
-const createUserSchema = Joi.func<typeof someFunction>();
-type extractFunction = Joi.extractType<typeof createUserSchema>;
+const createUserSchema = Joi.func();
+type extractFunction = JoiExtractType.extractType<typeof createUserSchema>;
 export const extractedFunction: extractFunction = someFunction;
 
 const number_string = Joi.alt().try(extJoi.number().valid(1, 2, 3), extJoi.string());
-type extractNumberString = Joi.extractType<typeof number_string>;
+type extractNumberString = JoiExtractType.extractType<typeof number_string>;
 export const extractNumberStringNumber: extractNumberString = 2;
 export const extractNumberStringString: extractNumberString = '2';
 
 const date_time1 = Joi.alternatives([Joi.date(), extJoi.number(), extJoi.string()]);
-type extractDateTime1 = Joi.extractType<typeof date_time1>;
+type extractDateTime1 = JoiExtractType.extractType<typeof date_time1>;
 export const extractDateTimeDate1: extractDateTime1 = new Date();
 export const extractDateTimeTime1: extractDateTime1 = +new Date();
 export const extractDateTimeString1: extractDateTime1 = new Date().toISOString();
 
 const when = Joi.alt().when('x', { is: 'a', then: extJoi.string(), otherwise: extJoi.number() });
-type extractedWhen = Joi.extractType<typeof when>;
+type extractedWhen = JoiExtractType.extractType<typeof when>;
 export const extractWhen1: extractedWhen = 2;
 export const extractWhen2: extractedWhen = '2';
 
@@ -163,7 +163,7 @@ const required_alt = Joi.object({
     value: when.required(),
   }).required(),
 });
-type extractedRequiredAlt = Joi.extractType<typeof required_alt>;
+type extractedRequiredAlt = JoiExtractType.extractType<typeof required_alt>;
 export const extractRequiredAlt: extractedRequiredAlt = {
   required: { start_date: new Date(), value: '2' },
 };
@@ -177,7 +177,7 @@ const required_alt_augmented = required_alt.keys({
     .pattern(extJoi.string(), extJoi.number())
     .pattern(extJoi.string().valid('pattern_key'), extJoi.number()),
 });
-type extractedRequiredAltAugmented = Joi.extractType<typeof required_alt_augmented>;
+type extractedRequiredAltAugmented = JoiExtractType.extractType<typeof required_alt_augmented>;
 export const extractRequiredAltAugmented: extractedRequiredAltAugmented = {
   required: {
     start_date: new Date(),
@@ -190,53 +190,50 @@ const string_array_schema = [
   extJoi.string().default('test' as 'test'),
   extJoi.array().items([extJoi.string(), extJoi.number()]).valid('string', 2), // TODO overwrite valid on ArraySchema
 ];
-type extractStringArray = Joi.extractType<typeof string_array_schema>;
+type extractStringArray = JoiExtractType.extractType<typeof string_array_schema>;
 export const extractStringArrayString: extractStringArray = 'string';
 export const extractStringArrayArray: extractStringArray = ['string', 2];
 
 // A extends B type guard
-type numberExtendsAny = Joi.extendsGuard<any, extractNumber>;
+type numberExtendsAny = JoiExtractType.extendsGuard<any, extractNumber>;
 export const asNumber: numberExtendsAny = 2;
 
-type stringNotNumber = Joi.extendsGuard<string, extractNumber>;
+type stringNotNumber = JoiExtractType.extendsGuard<string, extractNumber>;
 export const asString: stringNotNumber = 'string';
 
 // Validation methods
 type priorityValidationResponse = { error: any; value: extractNumber };
-export const validationExtractedNumber1: priorityValidationResponse = Joi.validate(
+export const validationExtractedNumber1: priorityValidationResponse = priority.validate(
   extractedNumber,
-  priority
 );
-export const validationExtractedNumber2: priorityValidationResponse = Joi.validate(
+export const validationExtractedNumber2: priorityValidationResponse = priority.validate(
   extractedNumber,
-  priority,
   {}
 );
 export const validatedNumber: number =
   validationExtractedNumber2.value || validationExtractedNumber1.value;
 
 type strictEnum = 'tag';
-export const validationOverwrittenReturn: strictEnum = Joi.validate(
-  extractedNumber,
+export const validationOverwrittenReturn: strictEnum = priority.validate(
   priority,
-  (_err, value: extractNumber) => {
+  (_err: Error | undefined, value: extractNumber) => {
     if (typeof value === 'number') return 'tag' as 'tag';
   }
 );
 
 const nullableString = extJoi.string().valid('string').allow(null, 0);
-type extractNullableString = Joi.extractType<typeof nullableString>;
-export const extactedNullableStringNull: extractNullableString = null;
-export const extactedNullableStringZero: extractNullableString = 0;
-export const extactedNullableString: extractNullableString = 'string';
+type extractNullableString = JoiExtractType.extractType<typeof nullableString>;
+export const extractedNullableStringNull: extractNullableString = null;
+export const extractedNullableStringZero: extractNullableString = 0;
+export const extractedNullableString: extractNullableString = 'string';
 
 const nullableNumber = extJoi
   .number()
   .allow(null as null)
   .default(5);
-type extractNullableNumber = Joi.extractType<typeof nullableNumber>;
-export const extactedNullableNumberNull: extractNullableNumber = null;
-export const extactedNullableNumber: extractNullableNumber = 15;
+type extractNullableNumber = JoiExtractType.extractType<typeof nullableNumber>;
+export const extractedNullableNumberNull: extractNullableNumber = null;
+export const extractedNullableNumber: extractNullableNumber = 15;
 
 const nullType = null as null;
 const allNullable = {
@@ -249,7 +246,7 @@ const allNullable = {
   nullableObject: Joi.object({ nullableString }).allow(nullType),
   nullableAlt: Joi.alt(nullableString, nullableNumber).allow(nullType),
 };
-type extractAllNullable = Joi.extractType<typeof allNullable>;
+type extractAllNullable = JoiExtractType.extractType<typeof allNullable>;
 export const extractedAllNullable: extractAllNullable = {
   nullableString: null,
   nullableNumber: null,
@@ -264,7 +261,7 @@ export const extractedAllNullable: extractAllNullable = {
 export const anyRequired = Joi.any().required();
 export const anyOptional = Joi.any();
 export const anyTestSchema = { anyRequired, anyOptional };
-type extractedAnyTest = Joi.extractType<typeof anyTestSchema>;
+type extractedAnyTest = JoiExtractType.extractType<typeof anyTestSchema>;
 
 export let anyTests: extractedAnyTest;
 anyTests = { anyRequired: 'test', anyOptional: 'test' };
@@ -283,7 +280,7 @@ const nestedObjSchema = Joi.object()
     }),
   });
 
-type extractNestedObjSchema = Joi.extractType<typeof nestedObjSchema>;
+type extractNestedObjSchema = JoiExtractType.extractType<typeof nestedObjSchema>;
 export const extractedNestedObjSchema: extractNestedObjSchema = {
   nested: {
     foo: 'string',
@@ -292,12 +289,12 @@ export const extractedNestedObjSchema: extractNestedObjSchema = {
 
 // Test for issue #36
 export const stdSchemaMethods = [
-  Joi.any().tags('tags').label('any'),
-  Joi.string().tags('tags').label('string'),
-  Joi.boolean().tags('tags').label('boolean'),
-  Joi.number().tags('tags').label('number'),
-  Joi.date().tags('tags').label('date'),
-  Joi.object().tags('tags').label('object'),
-  Joi.array().tags('tags').label('array'),
-  Joi.alt().tags('tags').label('alt'),
+  Joi.any().tag('tags').label('any'),
+  Joi.string().tag('tags').label('string'),
+  Joi.boolean().tag('tags').label('boolean'),
+  Joi.number().tag('tags').label('number'),
+  Joi.date().tag('tags').label('date'),
+  Joi.object().tag('tags').label('object'),
+  Joi.array().tag('tags').label('array'),
+  Joi.alt().tag('tags').label('alt'),
 ];

--- a/index.ts
+++ b/index.ts
@@ -65,83 +65,6 @@ export type mappedSchemaMap = { [K: string]: mappedSchema };
 
 export type extendsGuard<T, S> = S extends T ? S : T;
 
-export declare module JoiExtractType {
-  /**
-   * Validation: extraction decorated methods
-   */
-  export function validate<T, S extends mappedSchemaMap>(
-    value: T,
-    schema: S,
-  ): ValidationResult;
-  export function validate<T, S extends mappedSchemaMap>(
-    value: T,
-    schema: S,
-    options: ValidationOptions,
-  ): ValidationResult;
-  export function validate<T, R, S extends mappedSchemaMap>(
-    value: T,
-    schema: S,
-    options: ValidationOptions,
-    callback: (err: ValidationError, value: extendsGuard<T, extractType<S>>) => R,
-  ): R;
-  export function validate<T, R, S extends mappedSchemaMap>(
-    value: T,
-    schema: S,
-    callback: (err: ValidationError, value: extendsGuard<T, extractType<S>>) => R,
-  ): R;
-
-  /**
-   * Allow extend() to use Joi types by default
-   */
-  export function extend(
-    extension: Extension | Extension[],
-    ...extensions: Array<Extension | Extension[]>
-  ): typeof Joi;
-
-  // Factory methods.
-  export function any<T extends any>(): BoxAnySchema<Box<T, false>>;
-
-  export function string<T extends string>(): BoxStringSchema<Box<T, false>>;
-
-  export function number<T extends number>(): BoxNumberSchema<Box<T, false>>;
-
-  export function boolean<T extends boolean>(): BoxBooleanSchema<Box<T, false>>;
-
-  export function date<T extends Date>(): BoxDateSchema<Box<T, false>>;
-
-  export function func<T extends Function>(): BoxFunctionSchema<Box<T, false>>;
-
-  export function array(): BoxArraySchema<Box<never, false>>;
-
-  export function object<T extends mappedSchemaMap>(
-    schema?: T,
-  ): BoxObjectSchema<Box<extractMap<T>, false>>;
-
-  export function alternatives<T extends mappedSchema[]>(
-    ...alts: T
-  ): BoxAlternativesSchema<Box<extractType<typeof alts[number]>, false>>;
-  export function alternatives<T extends mappedSchema[]>(
-    alts: T,
-  ): BoxAlternativesSchema<Box<extractType<typeof alts[number]>, false>>;
-
-  export function alt<T extends mappedSchema[]>(
-    ...alts: T
-  ): BoxAlternativesSchema<Box<extractType<typeof alts[number]>, false>>;
-  export function alt<T extends mappedSchema[]>(
-    alts: T,
-  ): BoxAlternativesSchema<Box<extractType<typeof alts[number]>, false>>;
-}
-
-// TODO: concat
-// concat(schema: this): this;
-
-// TODO: when
-// when(ref: string, options: WhenOptions): BoxAlternativesSchema;
-// when(ref: Reference, options: WhenOptions): BoxAlternativesSchema;
-// when(ref: Schema, options: WhenSchemaOptions): BoxAlternativesSchema;
-
-// TODO: see if .default union makes sense;
-
 export interface BoxAnySchema<N extends Box<any, boolean>> extends AnySchema {
   __schemaTypeLiteral: 'BoxAnySchema';
 
@@ -698,5 +621,86 @@ export type extractType<T extends mappedSchema> =
            * Default case to handle primitives and schemas
            */
           extractOne<T>;
+
+export declare module Validate {
+  /**
+   * Validation: extraction decorated methods
+   */
+  export function validate<T, S extends mappedSchemaMap>(
+    value: T,
+    schema: S,
+  ): ValidationResult;
+  export function validate<T, S extends mappedSchemaMap>(
+    value: T,
+    schema: S,
+    options: ValidationOptions,
+  ): ValidationResult;
+  export function validate<T, R, S extends mappedSchemaMap>(
+    value: T,
+    schema: S,
+    options: ValidationOptions,
+    callback: (err: ValidationError, value: extendsGuard<T, extractType<S>>) => R,
+  ): R;
+  export function validate<T, R, S extends mappedSchemaMap>(
+    value: T,
+    schema: S,
+    callback: (err: ValidationError, value: extendsGuard<T, extractType<S>>) => R,
+  ): R;
+}
+
+export declare module Extend {
+  /**
+   * Allow extend() to use Joi types by default
+   */
+  export function extend(
+    extension: Extension | Extension[],
+    ...extensions: Array<Extension | Extension[]>
+  ): typeof Joi;
+}
+
+export declare module FactoryMethods {
+  // Factory methods.
+  export function any<T extends any>(): BoxAnySchema<Box<T, false>>;
+
+  export function string<T extends string>(): BoxStringSchema<Box<T, false>>;
+
+  export function number<T extends number>(): BoxNumberSchema<Box<T, false>>;
+
+  export function boolean<T extends boolean>(): BoxBooleanSchema<Box<T, false>>;
+
+  export function date<T extends Date>(): BoxDateSchema<Box<T, false>>;
+
+  export function func<T extends Function>(): BoxFunctionSchema<Box<T, false>>;
+
+  export function array(): BoxArraySchema<Box<never, false>>;
+
+  export function object<T extends mappedSchemaMap>(
+    schema?: T,
+  ): BoxObjectSchema<Box<extractMap<T>, false>>;
+
+  export function alternatives<T extends mappedSchema[]>(
+    ...alts: T
+  ): BoxAlternativesSchema<Box<extractType<typeof alts[number]>, false>>;
+  export function alternatives<T extends mappedSchema[]>(
+    alts: T,
+  ): BoxAlternativesSchema<Box<extractType<typeof alts[number]>, false>>;
+
+  export function alt<T extends mappedSchema[]>(
+    ...alts: T
+  ): BoxAlternativesSchema<Box<extractType<typeof alts[number]>, false>>;
+  export function alt<T extends mappedSchema[]>(
+    alts: T,
+  ): BoxAlternativesSchema<Box<extractType<typeof alts[number]>, false>>;
+}
+
+// TODO: concat
+// concat(schema: this): this;
+
+// TODO: when
+// when(ref: string, options: WhenOptions): BoxAlternativesSchema;
+// when(ref: Reference, options: WhenOptions): BoxAlternativesSchema;
+// when(ref: Schema, options: WhenSchemaOptions): BoxAlternativesSchema;
+
+// TODO: see if .default union makes sense;
 
 export default extractType;

--- a/index.ts
+++ b/index.ts
@@ -622,76 +622,78 @@ export type extractType<T extends mappedSchema> =
            */
           extractOne<T>;
 
-export declare module Validate {
-  /**
-   * Validation: extraction decorated methods
-   */
-  export function validate<T, S extends mappedSchemaMap>(
-    value: T,
-    schema: S,
-  ): ValidationResult;
-  export function validate<T, S extends mappedSchemaMap>(
-    value: T,
-    schema: S,
-    options: ValidationOptions,
-  ): ValidationResult;
-  export function validate<T, R, S extends mappedSchemaMap>(
-    value: T,
-    schema: S,
-    options: ValidationOptions,
-    callback: (err: ValidationError, value: extendsGuard<T, extractType<S>>) => R,
-  ): R;
-  export function validate<T, R, S extends mappedSchemaMap>(
-    value: T,
-    schema: S,
-    callback: (err: ValidationError, value: extendsGuard<T, extractType<S>>) => R,
-  ): R;
-}
+/**
+ * Validation: extraction decorated methods
+ */
+export declare function validate<T, S extends mappedSchemaMap>(
+  value: T,
+  schema: S,
+): ValidationResult;
 
-export declare module Extend {
-  /**
-   * Allow extend() to use Joi types by default
-   */
-  export function extend(
-    extension: Extension | Extension[],
-    ...extensions: Array<Extension | Extension[]>
-  ): typeof Joi;
-}
+export declare function validate<T, S extends mappedSchemaMap>(
+  value: T,
+  schema: S,
+): ValidationResult;
 
-export declare module FactoryMethods {
-  // Factory methods.
-  export function any<T extends any>(): BoxAnySchema<Box<T, false>>;
+export declare function validate<T, S extends mappedSchemaMap>(
+  value: T,
+  schema: S,
+  options: ValidationOptions,
+): ValidationResult;
 
-  export function string<T extends string>(): BoxStringSchema<Box<T, false>>;
+export declare function validate<T, R, S extends mappedSchemaMap>(
+  value: T,
+  schema: S,
+  options: ValidationOptions,
+  callback: (err: ValidationError, value: extendsGuard<T, extractType<S>>) => R,
+): R;
 
-  export function number<T extends number>(): BoxNumberSchema<Box<T, false>>;
+export declare function validate<T, R, S extends mappedSchemaMap>(
+  value: T,
+  schema: S,
+  callback: (err: ValidationError, value: extendsGuard<T, extractType<S>>) => R,
+): R;
 
-  export function boolean<T extends boolean>(): BoxBooleanSchema<Box<T, false>>;
+/**
+ * Allow extend() to use Joi types by default
+ */
+export declare function extend(
+  extension: Extension | Extension[],
+  ...extensions: Array<Extension | Extension[]>
+): typeof Joi;
 
-  export function date<T extends Date>(): BoxDateSchema<Box<T, false>>;
+// Factory methods.
+export declare function any<T extends any>(): BoxAnySchema<Box<T, false>>;
 
-  export function func<T extends Function>(): BoxFunctionSchema<Box<T, false>>;
+export declare function string<T extends string>(): BoxStringSchema<Box<T, false>>;
 
-  export function array(): BoxArraySchema<Box<never, false>>;
+export declare function number<T extends number>(): BoxNumberSchema<Box<T, false>>;
 
-  export function object<T extends mappedSchemaMap>(
-    schema?: T,
-  ): BoxObjectSchema<Box<extractMap<T>, false>>;
+export declare function boolean<T extends boolean>(): BoxBooleanSchema<Box<T, false>>;
 
-  export function alternatives<T extends mappedSchema[]>(
-    ...alts: T
-  ): BoxAlternativesSchema<Box<extractType<typeof alts[number]>, false>>;
-  export function alternatives<T extends mappedSchema[]>(
-    alts: T,
-  ): BoxAlternativesSchema<Box<extractType<typeof alts[number]>, false>>;
+export declare function date<T extends Date>(): BoxDateSchema<Box<T, false>>;
 
-  export function alt<T extends mappedSchema[]>(
-    ...alts: T
-  ): BoxAlternativesSchema<Box<extractType<typeof alts[number]>, false>>;
-  export function alt<T extends mappedSchema[]>(
-    alts: T,
-  ): BoxAlternativesSchema<Box<extractType<typeof alts[number]>, false>>;
-}
+export declare function func<T extends Function>(): BoxFunctionSchema<Box<T, false>>;
+
+export declare function array(): BoxArraySchema<Box<never, false>>;
+
+export declare function object<T extends mappedSchemaMap>(
+  schema?: T,
+): BoxObjectSchema<Box<extractMap<T>, false>>;
+
+export declare function alternatives<T extends mappedSchema[]>(
+  ...alts: T
+): BoxAlternativesSchema<Box<extractType<typeof alts[number]>, false>>;
+export declare function alternatives<T extends mappedSchema[]>(
+  alts: T,
+): BoxAlternativesSchema<Box<extractType<typeof alts[number]>, false>>;
+
+export declare function alt<T extends mappedSchema[]>(
+  ...alts: T
+): BoxAlternativesSchema<Box<extractType<typeof alts[number]>, false>>;
+export declare function alt<T extends mappedSchema[]>(
+  alts: T,
+): BoxAlternativesSchema<Box<extractType<typeof alts[number]>, false>>;
 
 // TODO: concat
 // concat(schema: this): this;

--- a/index.ts
+++ b/index.ts
@@ -25,7 +25,71 @@ import Joi, {
  */
 type ArrayType<T> = T extends (infer U)[] ? U : never;
 
-declare module JoiExtractType {
+/**
+ * Field requirements interface
+ */
+interface Box<T, R extends boolean> {
+  /** Type the schema holds */
+  T: T;
+  /** If this attribute is required when inside an object */
+  R: R;
+}
+
+// Operators
+type BoxType<B, nT> = B extends Box<infer oT, infer oR> ? Box<nT, oR> : B;
+type BoxUnion<B, nT> = B extends Box<infer oT, infer oR> ? Box<oT | nT, oR> : B;
+type BoxIntersection<B, nT> = B extends Box<infer oT, infer oR> ? Box<oT & nT, oR> : B;
+type BoxReq<B, nR extends boolean> = B extends Box<infer oT, infer oR> ? Box<oT, nR> : B;
+
+type BoxSchema = Box<any, boolean>;
+
+/**
+ * Every Schema that implements the Box to allow the extraction
+ */
+type BoxedPrimitive<T extends BoxSchema = any> =
+  | BoxAnySchema<T>
+  | BoxStringSchema<T>
+  | BoxNumberSchema<T>
+  | BoxBooleanSchema<T>
+  | BoxDateSchema<T>
+  | BoxFunctionSchema<T>
+  | BoxArraySchema<T>
+  | BoxObjectSchema<T>
+  | BoxAlternativesSchema<T>;
+
+// Base types
+type primitiveType = string | number | boolean | Function | Date | undefined | null | void;
+
+export type mappedSchema = SchemaLike | BoxedPrimitive;
+export type mappedSchemaMap = { [K: string]: mappedSchema };
+
+export type extendsGuard<T, S> = S extends T ? S : T;
+
+export declare module JoiExtractType {
+  /**
+   * Validation: extraction decorated methods
+   */
+  export function validate<T, S extends mappedSchemaMap>(
+    value: T,
+    schema: S,
+  ): ValidationResult;
+  export function validate<T, S extends mappedSchemaMap>(
+    value: T,
+    schema: S,
+    options: ValidationOptions,
+  ): ValidationResult;
+  export function validate<T, R, S extends mappedSchemaMap>(
+    value: T,
+    schema: S,
+    options: ValidationOptions,
+    callback: (err: ValidationError, value: extendsGuard<T, extractType<S>>) => R,
+  ): R;
+  export function validate<T, R, S extends mappedSchemaMap>(
+    value: T,
+    schema: S,
+    callback: (err: ValidationError, value: extendsGuard<T, extractType<S>>) => R,
+  ): R;
+
   /**
    * Allow extend() to use Joi types by default
    */
@@ -33,461 +97,6 @@ declare module JoiExtractType {
     extension: Extension | Extension[],
     ...extensions: Array<Extension | Extension[]>
   ): typeof Joi;
-
-  /**
-   * Field requirements interface
-   */
-  interface Box<T, R extends boolean> {
-    /** Type the schema holds */
-    T: T;
-    /** If this attribute is required when inside an object */
-    R: R;
-  }
-
-  // Operators
-  type BoxType<B, nT> = B extends Box<infer oT, infer oR> ? Box<nT, oR> : B;
-  type BoxUnion<B, nT> = B extends Box<infer oT, infer oR> ? Box<oT | nT, oR> : B;
-  type BoxIntersection<B, nT> = B extends Box<infer oT, infer oR> ? Box<oT & nT, oR> : B;
-  type BoxReq<B, nR extends boolean> = B extends Box<infer oT, infer oR> ? Box<oT, nR> : B;
-
-  type BoxSchema = Box<any, boolean>;
-
-  /**
-   * Every Schema that implements the Box to allow the extraction
-   */
-  type BoxedPrimitive<T extends BoxSchema = any> =
-    | BoxAnySchema<T>
-    | BoxStringSchema<T>
-    | BoxNumberSchema<T>
-    | BoxBooleanSchema<T>
-    | BoxDateSchema<T>
-    | BoxFunctionSchema<T>
-    | BoxArraySchema<T>
-    | BoxObjectSchema<T>
-    | BoxAlternativesSchema<T>;
-
-  // Base types
-  type primitiveType = string | number | boolean | Function | Date | undefined | null | void;
-
-  export type mappedSchema = SchemaLike | BoxedPrimitive;
-  export type mappedSchemaMap = { [K: string]: mappedSchema };
-
-  export type extendsGuard<T, S> = S extends T ? S : T;
-
-  /**
-   * Validation: extraction decorated methods
-   */
-  export function validate<T, S extends mappedSchemaMap>(
-    value: T,
-    schema: S
-  ): ValidationResult;
-  export function validate<T, S extends mappedSchemaMap>(
-    value: T,
-    schema: S,
-    options: ValidationOptions
-  ): ValidationResult;
-  export function validate<T, R, S extends mappedSchemaMap>(
-    value: T,
-    schema: S,
-    options: ValidationOptions,
-    callback: (err: ValidationError, value: extendsGuard<T, extractType<S>>) => R
-  ): R;
-  export function validate<T, R, S extends mappedSchemaMap>(
-    value: T,
-    schema: S,
-    callback: (err: ValidationError, value: extendsGuard<T, extractType<S>>) => R
-  ): R;
-
-  // TODO: concat
-  // concat(schema: this): this;
-
-  // TODO: when
-  // when(ref: string, options: WhenOptions): BoxAlternativesSchema;
-  // when(ref: Reference, options: WhenOptions): BoxAlternativesSchema;
-  // when(ref: Schema, options: WhenSchemaOptions): BoxAlternativesSchema;
-
-  // TODO: see if .default union makes sense;
-
-  export interface BoxAnySchema<N extends Box<any, boolean>> extends AnySchema {
-    __schemaTypeLiteral: 'BoxAnySchema';
-
-    default<T>(
-      value: T,
-      description?: string
-    ): this extends BoxAnySchema<infer B> ? BoxAnySchema<BoxUnion<B, T>> : never;
-    default(value: any, description?: string): this;
-    default(): this;
-
-    allow<T>(
-      ...values: T[]
-    ): this extends BoxAnySchema<infer B> ? BoxAnySchema<BoxUnion<B, T>> : never;
-    allow<T>(
-      values: T[]
-    ): this extends BoxAnySchema<infer B> ? BoxAnySchema<BoxUnion<B, T>> : never;
-    allow(...values: any[]): this;
-    allow(values: any[]): this;
-
-    valid<T>(
-      ...values: T[]
-    ): this extends BoxAnySchema<infer B> ? BoxAnySchema<BoxType<B, T>> : never;
-    valid<T>(values: T[]): this extends BoxAnySchema<infer B> ? BoxAnySchema<BoxType<B, T>> : never;
-    valid(...values: any[]): this;
-    valid(values: any[]): this;
-
-    required(): this extends BoxAnySchema<infer B> ? BoxAnySchema<BoxReq<B, true>> : never;
-    required(): this;
-    exist(): this extends BoxAnySchema<infer B> ? BoxAnySchema<BoxReq<B, true>> : never;
-    exist(): this;
-    optional(): this extends BoxAnySchema<infer B> ? BoxAnySchema<BoxReq<B, false>> : never;
-    optional(): this;
-  }
-
-  /**
-   * String: extraction decorated schema
-   */
-  export interface BoxStringSchema<N extends BoxSchema> extends StringSchema {
-    __schemaTypeLiteral: 'BoxStringSchema';
-
-    default<T extends string>(
-      value: T,
-      description?: string
-    ): this extends BoxStringSchema<infer B> ? BoxStringSchema<BoxUnion<B, T>> : never;
-    default(value: any, description?: string): this;
-    default(): this;
-
-    allow<T>(
-      ...values: T[]
-    ): this extends BoxStringSchema<infer B> ? BoxStringSchema<BoxUnion<B, T>> : never;
-    allow<T>(
-      values: T[]
-    ): this extends BoxStringSchema<infer B> ? BoxStringSchema<BoxUnion<B, T>> : never;
-    allow(...values: any[]): this;
-    allow(values: any[]): this;
-
-    valid<T extends string>(
-      ...values: T[]
-    ): this extends BoxStringSchema<infer B> ? BoxStringSchema<BoxType<B, T>> : never;
-    valid<T extends string>(
-      values: T[]
-    ): this extends BoxStringSchema<infer B> ? BoxStringSchema<BoxType<B, T>> : never;
-    valid(...values: any[]): this;
-    valid(values: any[]): this;
-
-    required(): this extends BoxStringSchema<infer B> ? BoxStringSchema<BoxReq<B, true>> : never;
-    required(): this;
-    exist(): this extends BoxStringSchema<infer B> ? BoxStringSchema<BoxReq<B, true>> : never;
-    exist(): this;
-    optional(): this extends BoxStringSchema<infer B> ? BoxStringSchema<BoxReq<B, false>> : never;
-    optional(): this;
-  }
-
-  /**
-   * Number: extraction decorated schema
-   */
-  export interface BoxNumberSchema<N extends BoxSchema> extends NumberSchema {
-    __schemaTypeLiteral: 'BoxNumberSchema';
-
-    default<T extends number>(
-      value: T,
-      description?: string
-    ): this extends BoxNumberSchema<infer B> ? BoxNumberSchema<BoxUnion<B, T>> : never;
-    default(value: any, description?: string): this;
-    default(): this;
-
-    allow<T>(
-      ...values: T[]
-    ): this extends BoxNumberSchema<infer B> ? BoxNumberSchema<BoxUnion<B, T>> : never;
-    allow<T>(
-      values: T[]
-    ): this extends BoxNumberSchema<infer B> ? BoxNumberSchema<BoxUnion<B, T>> : never;
-    allow(...values: any[]): this;
-    allow(values: any[]): this;
-
-    valid<T extends string>(
-      ...values: T[]
-    ): this extends BoxNumberSchema<infer B> ? BoxNumberSchema<BoxType<B, T>> : never;
-    valid<T extends string>(
-      values: T[]
-    ): this extends BoxNumberSchema<infer B> ? BoxNumberSchema<BoxType<B, T>> : never;
-    valid(...values: any[]): this;
-    valid(values: any[]): this;
-
-    required(): this extends BoxNumberSchema<infer B> ? BoxNumberSchema<BoxReq<B, true>> : never;
-    required(): this;
-    exist(): this extends BoxNumberSchema<infer B> ? BoxNumberSchema<BoxReq<B, true>> : never;
-    exist(): this;
-    optional(): this extends BoxNumberSchema<infer B> ? BoxNumberSchema<BoxReq<B, false>> : never;
-    optional(): this;
-  }
-
-  /**
-   * Boolean: extraction decorated schema
-   */
-  export interface BoxBooleanSchema<N extends BoxSchema> extends BooleanSchema {
-    __schemaTypeLiteral: 'BoxBooleanSchema';
-
-    default<T extends boolean>(
-      value: T,
-      description?: string
-    ): this extends BoxBooleanSchema<infer B> ? BoxBooleanSchema<BoxUnion<B, T>> : never;
-    default(value: any, description?: string): this;
-    default(): this;
-
-    allow<T>(
-      ...values: T[]
-    ): this extends BoxBooleanSchema<infer B> ? BoxBooleanSchema<BoxUnion<B, T>> : never;
-    allow<T>(
-      values: T[]
-    ): this extends BoxBooleanSchema<infer B> ? BoxBooleanSchema<BoxUnion<B, T>> : never;
-    allow(...values: any[]): this;
-    allow(values: any[]): this;
-
-    valid<T extends string>(
-      ...values: T[]
-    ): this extends BoxBooleanSchema<infer B> ? BoxBooleanSchema<BoxType<B, T>> : never;
-    valid<T extends string>(
-      values: T[]
-    ): this extends BoxBooleanSchema<infer B> ? BoxBooleanSchema<BoxType<B, T>> : never;
-    valid(...values: any[]): this;
-    valid(values: any[]): this;
-
-    required(): this extends BoxBooleanSchema<infer B> ? BoxBooleanSchema<BoxReq<B, true>> : never;
-    required(): this;
-    exist(): this extends BoxBooleanSchema<infer B> ? BoxBooleanSchema<BoxReq<B, true>> : never;
-    exist(): this;
-    optional(): this extends BoxBooleanSchema<infer B> ? BoxBooleanSchema<BoxReq<B, false>> : never;
-    optional(): this;
-  }
-
-  /**
-   * Date: extraction decorated schema
-   */
-  export interface BoxDateSchema<N extends BoxSchema> extends DateSchema {
-    __schemaTypeLiteral: 'BoxDateSchema';
-
-    default<T extends Date>(
-      value: T,
-      description?: string
-    ): this extends BoxDateSchema<infer B> ? BoxDateSchema<BoxUnion<B, T>> : never;
-    default(value: any, description?: string): this;
-    default(): this;
-
-    allow<T>(
-      ...values: T[]
-    ): this extends BoxDateSchema<infer B> ? BoxDateSchema<BoxUnion<B, T>> : never;
-    allow<T>(
-      values: T[]
-    ): this extends BoxDateSchema<infer B> ? BoxDateSchema<BoxUnion<B, T>> : never;
-    allow(...values: any[]): this;
-    allow(values: any[]): this;
-
-    valid<T extends string>(
-      ...values: T[]
-    ): this extends BoxDateSchema<infer B> ? BoxDateSchema<BoxType<B, T>> : never;
-    valid<T extends string>(
-      values: T[]
-    ): this extends BoxDateSchema<infer B> ? BoxDateSchema<BoxType<B, T>> : never;
-    valid(...values: any[]): this;
-    valid(values: any[]): this;
-
-    required(): this extends BoxDateSchema<infer B> ? BoxDateSchema<BoxReq<B, true>> : never;
-    required(): this;
-    exist(): this extends BoxDateSchema<infer B> ? BoxDateSchema<BoxReq<B, true>> : never;
-    exist(): this;
-    optional(): this extends BoxDateSchema<infer B> ? BoxDateSchema<BoxReq<B, false>> : never;
-    optional(): this;
-  }
-
-  /**
-   * Function: extraction decorated schema
-   */
-  export interface BoxFunctionSchema<N extends BoxSchema> extends FunctionSchema {
-    __schemaTypeLiteral: 'BoxFunctionSchema';
-
-    allow<T>(
-      ...values: T[]
-    ): this extends BoxFunctionSchema<infer B> ? BoxFunctionSchema<BoxUnion<B, T>> : never;
-    allow<T>(
-      values: T[]
-    ): this extends BoxFunctionSchema<infer B> ? BoxFunctionSchema<BoxUnion<B, T>> : never;
-    allow(...values: any[]): this;
-    allow(values: any[]): this;
-
-    required(): this extends BoxFunctionSchema<infer B>
-      ? BoxFunctionSchema<BoxReq<B, true>>
-      : never;
-    required(): this;
-    exist(): this extends BoxFunctionSchema<infer B> ? BoxFunctionSchema<BoxReq<B, true>> : never;
-    exist(): this;
-    optional(): this extends BoxFunctionSchema<infer B>
-      ? BoxFunctionSchema<BoxReq<B, false>>
-      : never;
-    optional(): this;
-  }
-
-  /**
-   * Array: extraction decorated schema
-   */
-  export interface BoxArraySchema<N extends BoxSchema> extends ArraySchema {
-    __schemaTypeLiteral: 'BoxArraySchema';
-
-    default<T extends any[]>(
-      value: T,
-      description?: string
-    ): this extends BoxArraySchema<infer B> ? BoxArraySchema<BoxUnion<B, ArrayType<T>>> : never;
-
-    default(value: any, description?: string): this;
-    default(): this;
-
-    allow<T>(
-      ...values: T[]
-    ): this extends BoxArraySchema<infer B> ? BoxArraySchema<BoxUnion<B, T>> : never;
-    allow<T>(
-      values: T[]
-    ): this extends BoxArraySchema<infer B> ? BoxArraySchema<BoxUnion<B, T>> : never;
-    allow(...values: any[]): this;
-    allow(values: any[]): this;
-
-    items<T extends mappedSchema>(
-      type: T
-    ): this extends BoxArraySchema<infer B> ? BoxArraySchema<BoxUnion<B, extractType<T>>> : never;
-
-    items(...types: SchemaLike[]): this;
-    items(types: SchemaLike[]): this;
-
-    required(): this extends BoxArraySchema<infer B> ? BoxArraySchema<BoxReq<B, true>> : never;
-    required(): this;
-    exist(): this extends BoxArraySchema<infer B> ? BoxArraySchema<BoxReq<B, true>> : never;
-    exist(): this;
-    optional(): this extends BoxArraySchema<infer B> ? BoxArraySchema<BoxReq<B, false>> : never;
-    optional(): this;
-  }
-
-  /**
-   * Object: extraction decorated schema
-   */
-  export interface BoxObjectSchema<N extends BoxSchema> extends ObjectSchema {
-    __schemaTypeLiteral: 'BoxObjectSchema';
-
-    default<T extends mappedSchemaMap>(
-      value: T,
-      description?: string
-    ): this extends BoxObjectSchema<infer B> ? BoxObjectSchema<BoxUnion<B, extractType<T>>> : never;
-    default(value: any, description?: string): this;
-    default(): this;
-
-    allow<T>(
-      ...values: T[]
-    ): this extends BoxObjectSchema<infer B> ? BoxObjectSchema<BoxUnion<B, T>> : never;
-    allow<T>(
-      values: T[]
-    ): this extends BoxObjectSchema<infer B> ? BoxObjectSchema<BoxUnion<B, T>> : never;
-    allow(...values: any[]): this;
-    allow(values: any[]): this;
-
-    keys<T extends mappedSchemaMap>(
-      schema: T
-    ): this extends BoxObjectSchema<infer B>
-      ? BoxObjectSchema<BoxIntersection<B, extractMap<T>>>
-      : never;
-    keys(schema?: SchemaMap): this;
-
-    append<T extends mappedSchemaMap>(
-      schema: T
-    ): this extends BoxObjectSchema<infer B>
-      ? BoxObjectSchema<BoxIntersection<B, extractMap<T>>>
-      : never;
-    append(schema?: SchemaMap): this;
-
-    pattern<S extends BoxStringSchema<any>, T extends mappedSchema>(
-      pattern: S,
-      schema: T
-    ): this extends BoxObjectSchema<infer B>
-      ? BoxObjectSchema<BoxIntersection<B, extractMap<{ [key in extractType<S>]: T }>>>
-      : never;
-    pattern<T extends mappedSchema>(
-      pattern: RegExp,
-      schema: T
-    ): this extends BoxObjectSchema<infer B>
-      ? BoxObjectSchema<BoxIntersection<B, extractMap<{ [key: string]: T }>>>
-      : never;
-
-    pattern(pattern: RegExp | SchemaLike, schema: SchemaLike): this;
-
-    required(): this extends BoxObjectSchema<infer B> ? BoxObjectSchema<BoxReq<B, true>> : never;
-    required(): this;
-    exist(): this extends BoxObjectSchema<infer B> ? BoxObjectSchema<BoxReq<B, true>> : never;
-    exist(): this;
-    optional(): this extends BoxObjectSchema<infer B> ? BoxObjectSchema<BoxReq<B, false>> : never;
-    optional(): this;
-  }
-
-  /**
-   * Alternatives: extraction decorated schema
-   */
-  export interface BoxAlternativesSchema<N extends BoxSchema> extends AlternativesSchema {
-    __schemaTypeLiteral: 'BoxAlternativesSchema';
-
-    allow<T>(
-      ...values: T[]
-    ): this extends BoxAlternativesSchema<infer B> ? BoxAlternativesSchema<BoxUnion<B, T>> : never;
-    allow<T>(
-      values: T[]
-    ): this extends BoxAlternativesSchema<infer B> ? BoxAlternativesSchema<BoxUnion<B, T>> : never;
-    allow(...values: any[]): this;
-    allow(values: any[]): this;
-
-    try<T extends mappedSchema[]>(
-      ...values: T
-    ): this extends BoxAlternativesSchema<infer O>
-      ? O extends Box<infer oT, infer oR>
-        ? BoxAlternativesSchema<BoxType<O, oT | extractType<T>>>
-        : BoxAlternativesSchema<Box<extractType<T>, false>>
-      : BoxAlternativesSchema<Box<extractType<T>, false>>;
-
-    try<T extends mappedSchema[]>(
-      values: T
-    ): this extends BoxAlternativesSchema<infer O>
-      ? O extends Box<infer oT, infer oR>
-        ? BoxAlternativesSchema<BoxType<O, oT | extractType<T>>>
-        : BoxAlternativesSchema<Box<extractType<T>, false>>
-      : BoxAlternativesSchema<Box<extractType<T>, false>>;
-
-    try(...types: SchemaLike[]): this;
-    try(types: SchemaLike[]): this;
-
-    required(): this extends BoxAlternativesSchema<infer B>
-      ? BoxAlternativesSchema<BoxReq<B, true>>
-      : never;
-    required(): this;
-    exist(): this extends BoxAlternativesSchema<infer B>
-      ? BoxAlternativesSchema<BoxReq<B, true>>
-      : never;
-    exist(): this;
-    optional(): this extends BoxAlternativesSchema<infer B>
-      ? BoxAlternativesSchema<BoxReq<B, false>>
-      : never;
-    optional(): this;
-
-    when<
-      R,
-      T1 extends mappedSchema,
-      T2 extends mappedSchema,
-      T extends { then: T1; otherwise: T2 }
-    >(
-      ref: R,
-      defs: T
-    ): this extends BoxAlternativesSchema<infer O>
-      ? O extends Box<infer oT, infer oR>
-        ? BoxAlternativesSchema<
-            BoxType<O, oT | extractType<T['then']> | extractType<T['otherwise']>>
-          >
-        : BoxAlternativesSchema<Box<extractType<T['then']> | extractType<T['otherwise']>, false>>
-      : BoxAlternativesSchema<Box<extractType<T['then']> | extractType<T['otherwise']>, false>>;
-
-    when(ref: string | Reference, options: WhenOptions): this;
-    when(ref: Schema, options: WhenSchemaOptions): this;
-  }
 
   // Factory methods.
   export function any<T extends any>(): BoxAnySchema<Box<T, false>>;
@@ -505,78 +114,572 @@ declare module JoiExtractType {
   export function array(): BoxArraySchema<Box<never, false>>;
 
   export function object<T extends mappedSchemaMap>(
-    schema?: T
+    schema?: T,
   ): BoxObjectSchema<Box<extractMap<T>, false>>;
 
   export function alternatives<T extends mappedSchema[]>(
     ...alts: T
   ): BoxAlternativesSchema<Box<extractType<typeof alts[number]>, false>>;
   export function alternatives<T extends mappedSchema[]>(
-    alts: T
+    alts: T,
   ): BoxAlternativesSchema<Box<extractType<typeof alts[number]>, false>>;
 
   export function alt<T extends mappedSchema[]>(
     ...alts: T
   ): BoxAlternativesSchema<Box<extractType<typeof alts[number]>, false>>;
   export function alt<T extends mappedSchema[]>(
-    alts: T
+    alts: T,
   ): BoxAlternativesSchema<Box<extractType<typeof alts[number]>, false>>;
+}
 
-  // Required | Optional properties engine
-  // prettier-ignore
-  type Required<T, K = keyof T> = {
-    [j in K extends keyof T
-      ? T[K] extends BoxedPrimitive<infer B> ? B['R'] extends true ? K : never : never
-      : never]: true
-  };
-  // prettier-ignore
-  type Optional<T, K = keyof T> = {
-    [j in K extends keyof T
-      ? T[K] extends BoxedPrimitive<infer B> ? B['R'] extends false ? K : never : never
-      : never]: true
-  };
+// TODO: concat
+// concat(schema: this): this;
 
-  // prettier-ignore
-  type extractMap<T extends mappedSchemaMap> =
-    { [K in keyof Optional<T>]?: extractType<T[K]> } &
-    { [K in keyof Required<T>]: extractType<T[K]> };
+// TODO: when
+// when(ref: string, options: WhenOptions): BoxAlternativesSchema;
+// when(ref: Reference, options: WhenOptions): BoxAlternativesSchema;
+// when(ref: Schema, options: WhenSchemaOptions): BoxAlternativesSchema;
 
-  type maybeExtractBox<T> = T extends Box<infer O, infer R> ? O : T;
+// TODO: see if .default union makes sense;
 
-  // prettier-ignore
-  type extractOne<T extends mappedSchema> =
-    /** Primitive types */
-    T extends primitiveType ? T :
+export interface BoxAnySchema<N extends Box<any, boolean>> extends AnySchema {
+  __schemaTypeLiteral: 'BoxAnySchema';
+
+  default<T>(
+    value: T,
+    description?: string,
+  ): this extends BoxAnySchema<infer B> ? BoxAnySchema<BoxUnion<B, T>> : never;
+
+  default(value: any, description?: string): this;
+
+  default(): this;
+
+  allow<T>(
+    ...values: T[]
+  ): this extends BoxAnySchema<infer B> ? BoxAnySchema<BoxUnion<B, T>> : never;
+
+  allow<T>(
+    values: T[],
+  ): this extends BoxAnySchema<infer B> ? BoxAnySchema<BoxUnion<B, T>> : never;
+
+  allow(...values: any[]): this;
+
+  allow(values: any[]): this;
+
+  valid<T>(
+    ...values: T[]
+  ): this extends BoxAnySchema<infer B> ? BoxAnySchema<BoxType<B, T>> : never;
+
+  valid<T>(values: T[]): this extends BoxAnySchema<infer B> ? BoxAnySchema<BoxType<B, T>> : never;
+
+  valid(...values: any[]): this;
+
+  valid(values: any[]): this;
+
+  required(): this extends BoxAnySchema<infer B> ? BoxAnySchema<BoxReq<B, true>> : never;
+
+  required(): this;
+
+  exist(): this extends BoxAnySchema<infer B> ? BoxAnySchema<BoxReq<B, true>> : never;
+
+  exist(): this;
+
+  optional(): this extends BoxAnySchema<infer B> ? BoxAnySchema<BoxReq<B, false>> : never;
+
+  optional(): this;
+}
+
+/**
+ * String: extraction decorated schema
+ */
+export interface BoxStringSchema<N extends BoxSchema> extends StringSchema {
+  __schemaTypeLiteral: 'BoxStringSchema';
+
+  default<T extends string>(
+    value: T,
+    description?: string,
+  ): this extends BoxStringSchema<infer B> ? BoxStringSchema<BoxUnion<B, T>> : never;
+
+  default(value: any, description?: string): this;
+
+  default(): this;
+
+  allow<T>(
+    ...values: T[]
+  ): this extends BoxStringSchema<infer B> ? BoxStringSchema<BoxUnion<B, T>> : never;
+
+  allow<T>(
+    values: T[],
+  ): this extends BoxStringSchema<infer B> ? BoxStringSchema<BoxUnion<B, T>> : never;
+
+  allow(...values: any[]): this;
+
+  allow(values: any[]): this;
+
+  valid<T extends string>(
+    ...values: T[]
+  ): this extends BoxStringSchema<infer B> ? BoxStringSchema<BoxType<B, T>> : never;
+
+  valid<T extends string>(
+    values: T[],
+  ): this extends BoxStringSchema<infer B> ? BoxStringSchema<BoxType<B, T>> : never;
+
+  valid(...values: any[]): this;
+
+  valid(values: any[]): this;
+
+  required(): this extends BoxStringSchema<infer B> ? BoxStringSchema<BoxReq<B, true>> : never;
+
+  required(): this;
+
+  exist(): this extends BoxStringSchema<infer B> ? BoxStringSchema<BoxReq<B, true>> : never;
+
+  exist(): this;
+
+  optional(): this extends BoxStringSchema<infer B> ? BoxStringSchema<BoxReq<B, false>> : never;
+
+  optional(): this;
+}
+
+/**
+ * Number: extraction decorated schema
+ */
+export interface BoxNumberSchema<N extends BoxSchema> extends NumberSchema {
+  __schemaTypeLiteral: 'BoxNumberSchema';
+
+  default<T extends number>(
+    value: T,
+    description?: string,
+  ): this extends BoxNumberSchema<infer B> ? BoxNumberSchema<BoxUnion<B, T>> : never;
+
+  default(value: any, description?: string): this;
+
+  default(): this;
+
+  allow<T>(
+    ...values: T[]
+  ): this extends BoxNumberSchema<infer B> ? BoxNumberSchema<BoxUnion<B, T>> : never;
+
+  allow<T>(
+    values: T[],
+  ): this extends BoxNumberSchema<infer B> ? BoxNumberSchema<BoxUnion<B, T>> : never;
+
+  allow(...values: any[]): this;
+
+  allow(values: any[]): this;
+
+  valid<T extends string>(
+    ...values: T[]
+  ): this extends BoxNumberSchema<infer B> ? BoxNumberSchema<BoxType<B, T>> : never;
+
+  valid<T extends string>(
+    values: T[],
+  ): this extends BoxNumberSchema<infer B> ? BoxNumberSchema<BoxType<B, T>> : never;
+
+  valid(...values: any[]): this;
+
+  valid(values: any[]): this;
+
+  required(): this extends BoxNumberSchema<infer B> ? BoxNumberSchema<BoxReq<B, true>> : never;
+
+  required(): this;
+
+  exist(): this extends BoxNumberSchema<infer B> ? BoxNumberSchema<BoxReq<B, true>> : never;
+
+  exist(): this;
+
+  optional(): this extends BoxNumberSchema<infer B> ? BoxNumberSchema<BoxReq<B, false>> : never;
+
+  optional(): this;
+}
+
+/**
+ * Boolean: extraction decorated schema
+ */
+export interface BoxBooleanSchema<N extends BoxSchema> extends BooleanSchema {
+  __schemaTypeLiteral: 'BoxBooleanSchema';
+
+  default<T extends boolean>(
+    value: T,
+    description?: string,
+  ): this extends BoxBooleanSchema<infer B> ? BoxBooleanSchema<BoxUnion<B, T>> : never;
+
+  default(value: any, description?: string): this;
+
+  default(): this;
+
+  allow<T>(
+    ...values: T[]
+  ): this extends BoxBooleanSchema<infer B> ? BoxBooleanSchema<BoxUnion<B, T>> : never;
+
+  allow<T>(
+    values: T[],
+  ): this extends BoxBooleanSchema<infer B> ? BoxBooleanSchema<BoxUnion<B, T>> : never;
+
+  allow(...values: any[]): this;
+
+  allow(values: any[]): this;
+
+  valid<T extends string>(
+    ...values: T[]
+  ): this extends BoxBooleanSchema<infer B> ? BoxBooleanSchema<BoxType<B, T>> : never;
+
+  valid<T extends string>(
+    values: T[],
+  ): this extends BoxBooleanSchema<infer B> ? BoxBooleanSchema<BoxType<B, T>> : never;
+
+  valid(...values: any[]): this;
+
+  valid(values: any[]): this;
+
+  required(): this extends BoxBooleanSchema<infer B> ? BoxBooleanSchema<BoxReq<B, true>> : never;
+
+  required(): this;
+
+  exist(): this extends BoxBooleanSchema<infer B> ? BoxBooleanSchema<BoxReq<B, true>> : never;
+
+  exist(): this;
+
+  optional(): this extends BoxBooleanSchema<infer B> ? BoxBooleanSchema<BoxReq<B, false>> : never;
+
+  optional(): this;
+}
+
+/**
+ * Date: extraction decorated schema
+ */
+export interface BoxDateSchema<N extends BoxSchema> extends DateSchema {
+  __schemaTypeLiteral: 'BoxDateSchema';
+
+  default<T extends Date>(
+    value: T,
+    description?: string,
+  ): this extends BoxDateSchema<infer B> ? BoxDateSchema<BoxUnion<B, T>> : never;
+
+  default(value: any, description?: string): this;
+
+  default(): this;
+
+  allow<T>(
+    ...values: T[]
+  ): this extends BoxDateSchema<infer B> ? BoxDateSchema<BoxUnion<B, T>> : never;
+
+  allow<T>(
+    values: T[],
+  ): this extends BoxDateSchema<infer B> ? BoxDateSchema<BoxUnion<B, T>> : never;
+
+  allow(...values: any[]): this;
+
+  allow(values: any[]): this;
+
+  valid<T extends string>(
+    ...values: T[]
+  ): this extends BoxDateSchema<infer B> ? BoxDateSchema<BoxType<B, T>> : never;
+
+  valid<T extends string>(
+    values: T[],
+  ): this extends BoxDateSchema<infer B> ? BoxDateSchema<BoxType<B, T>> : never;
+
+  valid(...values: any[]): this;
+
+  valid(values: any[]): this;
+
+  required(): this extends BoxDateSchema<infer B> ? BoxDateSchema<BoxReq<B, true>> : never;
+
+  required(): this;
+
+  exist(): this extends BoxDateSchema<infer B> ? BoxDateSchema<BoxReq<B, true>> : never;
+
+  exist(): this;
+
+  optional(): this extends BoxDateSchema<infer B> ? BoxDateSchema<BoxReq<B, false>> : never;
+
+  optional(): this;
+}
+
+/**
+ * Function: extraction decorated schema
+ */
+export interface BoxFunctionSchema<N extends BoxSchema> extends FunctionSchema {
+  __schemaTypeLiteral: 'BoxFunctionSchema';
+
+  allow<T>(
+    ...values: T[]
+  ): this extends BoxFunctionSchema<infer B> ? BoxFunctionSchema<BoxUnion<B, T>> : never;
+
+  allow<T>(
+    values: T[],
+  ): this extends BoxFunctionSchema<infer B> ? BoxFunctionSchema<BoxUnion<B, T>> : never;
+
+  allow(...values: any[]): this;
+
+  allow(values: any[]): this;
+
+  required(): this extends BoxFunctionSchema<infer B>
+    ? BoxFunctionSchema<BoxReq<B, true>>
+    : never;
+
+  required(): this;
+
+  exist(): this extends BoxFunctionSchema<infer B> ? BoxFunctionSchema<BoxReq<B, true>> : never;
+
+  exist(): this;
+
+  optional(): this extends BoxFunctionSchema<infer B>
+    ? BoxFunctionSchema<BoxReq<B, false>>
+    : never;
+
+  optional(): this;
+}
+
+/**
+ * Array: extraction decorated schema
+ */
+export interface BoxArraySchema<N extends BoxSchema> extends ArraySchema {
+  __schemaTypeLiteral: 'BoxArraySchema';
+
+  default<T extends any[]>(
+    value: T,
+    description?: string,
+  ): this extends BoxArraySchema<infer B> ? BoxArraySchema<BoxUnion<B, ArrayType<T>>> : never;
+
+  default(value: any, description?: string): this;
+
+  default(): this;
+
+  allow<T>(
+    ...values: T[]
+  ): this extends BoxArraySchema<infer B> ? BoxArraySchema<BoxUnion<B, T>> : never;
+
+  allow<T>(
+    values: T[],
+  ): this extends BoxArraySchema<infer B> ? BoxArraySchema<BoxUnion<B, T>> : never;
+
+  allow(...values: any[]): this;
+
+  allow(values: any[]): this;
+
+  items<T extends mappedSchema>(
+    type: T,
+  ): this extends BoxArraySchema<infer B> ? BoxArraySchema<BoxUnion<B, extractType<T>>> : never;
+
+  items(...types: SchemaLike[]): this;
+
+  items(types: SchemaLike[]): this;
+
+  required(): this extends BoxArraySchema<infer B> ? BoxArraySchema<BoxReq<B, true>> : never;
+
+  required(): this;
+
+  exist(): this extends BoxArraySchema<infer B> ? BoxArraySchema<BoxReq<B, true>> : never;
+
+  exist(): this;
+
+  optional(): this extends BoxArraySchema<infer B> ? BoxArraySchema<BoxReq<B, false>> : never;
+
+  optional(): this;
+}
+
+/**
+ * Object: extraction decorated schema
+ */
+export interface BoxObjectSchema<N extends BoxSchema> extends ObjectSchema {
+  __schemaTypeLiteral: 'BoxObjectSchema';
+
+  default<T extends mappedSchemaMap>(
+    value: T,
+    description?: string,
+  ): this extends BoxObjectSchema<infer B> ? BoxObjectSchema<BoxUnion<B, extractType<T>>> : never;
+
+  default(value: any, description?: string): this;
+
+  default(): this;
+
+  allow<T>(
+    ...values: T[]
+  ): this extends BoxObjectSchema<infer B> ? BoxObjectSchema<BoxUnion<B, T>> : never;
+
+  allow<T>(
+    values: T[],
+  ): this extends BoxObjectSchema<infer B> ? BoxObjectSchema<BoxUnion<B, T>> : never;
+
+  allow(...values: any[]): this;
+
+  allow(values: any[]): this;
+
+  keys<T extends mappedSchemaMap>(
+    schema: T,
+  ): this extends BoxObjectSchema<infer B>
+    ? BoxObjectSchema<BoxIntersection<B, extractMap<T>>>
+    : never;
+
+  keys(schema?: SchemaMap): this;
+
+  append<T extends mappedSchemaMap>(
+    schema: T,
+  ): this extends BoxObjectSchema<infer B>
+    ? BoxObjectSchema<BoxIntersection<B, extractMap<T>>>
+    : never;
+
+  append(schema?: SchemaMap): this;
+
+  pattern<S extends BoxStringSchema<any>, T extends mappedSchema>(
+    pattern: S,
+    schema: T,
+  ): this extends BoxObjectSchema<infer B>
+    ? BoxObjectSchema<BoxIntersection<B, extractMap<{ [key in extractType<S>]: T }>>>
+    : never;
+
+  pattern<T extends mappedSchema>(
+    pattern: RegExp,
+    schema: T,
+  ): this extends BoxObjectSchema<infer B>
+    ? BoxObjectSchema<BoxIntersection<B, extractMap<{ [key: string]: T }>>>
+    : never;
+
+  pattern(pattern: RegExp | SchemaLike, schema: SchemaLike): this;
+
+  required(): this extends BoxObjectSchema<infer B> ? BoxObjectSchema<BoxReq<B, true>> : never;
+
+  required(): this;
+
+  exist(): this extends BoxObjectSchema<infer B> ? BoxObjectSchema<BoxReq<B, true>> : never;
+
+  exist(): this;
+
+  optional(): this extends BoxObjectSchema<infer B> ? BoxObjectSchema<BoxReq<B, false>> : never;
+
+  optional(): this;
+}
+
+/**
+ * Alternatives: extraction decorated schema
+ */
+export interface BoxAlternativesSchema<N extends BoxSchema> extends AlternativesSchema {
+  __schemaTypeLiteral: 'BoxAlternativesSchema';
+
+  allow<T>(
+    ...values: T[]
+  ): this extends BoxAlternativesSchema<infer B> ? BoxAlternativesSchema<BoxUnion<B, T>> : never;
+
+  allow<T>(
+    values: T[],
+  ): this extends BoxAlternativesSchema<infer B> ? BoxAlternativesSchema<BoxUnion<B, T>> : never;
+
+  allow(...values: any[]): this;
+
+  allow(values: any[]): this;
+
+  try<T extends mappedSchema[]>(
+    ...values: T
+  ): this extends BoxAlternativesSchema<infer O>
+    ? O extends Box<infer oT, infer oR>
+      ? BoxAlternativesSchema<BoxType<O, oT | extractType<T>>>
+      : BoxAlternativesSchema<Box<extractType<T>, false>>
+    : BoxAlternativesSchema<Box<extractType<T>, false>>;
+
+  try<T extends mappedSchema[]>(
+    values: T,
+  ): this extends BoxAlternativesSchema<infer O>
+    ? O extends Box<infer oT, infer oR>
+      ? BoxAlternativesSchema<BoxType<O, oT | extractType<T>>>
+      : BoxAlternativesSchema<Box<extractType<T>, false>>
+    : BoxAlternativesSchema<Box<extractType<T>, false>>;
+
+  try(...types: SchemaLike[]): this;
+
+  try(types: SchemaLike[]): this;
+
+  required(): this extends BoxAlternativesSchema<infer B>
+    ? BoxAlternativesSchema<BoxReq<B, true>>
+    : never;
+
+  required(): this;
+
+  exist(): this extends BoxAlternativesSchema<infer B>
+    ? BoxAlternativesSchema<BoxReq<B, true>>
+    : never;
+
+  exist(): this;
+
+  optional(): this extends BoxAlternativesSchema<infer B>
+    ? BoxAlternativesSchema<BoxReq<B, false>>
+    : never;
+
+  optional(): this;
+
+  when<R,
+    T1 extends mappedSchema,
+    T2 extends mappedSchema,
+    T extends { then: T1; otherwise: T2 }>(
+    ref: R,
+    defs: T,
+  ): this extends BoxAlternativesSchema<infer O>
+    ? O extends Box<infer oT, infer oR>
+      ? BoxAlternativesSchema<BoxType<O, oT | extractType<T['then']> | extractType<T['otherwise']>>>
+      : BoxAlternativesSchema<Box<extractType<T['then']> | extractType<T['otherwise']>, false>>
+    : BoxAlternativesSchema<Box<extractType<T['then']> | extractType<T['otherwise']>, false>>;
+
+  when(ref: string | Reference, options: WhenOptions): this;
+
+  when(ref: Schema, options: WhenSchemaOptions): this;
+}
+
+// Required | Optional properties engine
+// prettier-ignore
+type Required<T, K = keyof T> = {
+  [j in K extends keyof T
+    ? T[K] extends BoxedPrimitive<infer B> ? B['R'] extends true ? K : never : never
+    : never]: true
+};
+// prettier-ignore
+type Optional<T, K = keyof T> = {
+  [j in K extends keyof T
+    ? T[K] extends BoxedPrimitive<infer B> ? B['R'] extends false ? K : never : never
+    : never]: true
+};
+
+// prettier-ignore
+type extractMap<T extends mappedSchemaMap> =
+  { [K in keyof Optional<T>]?: extractType<T[K]> } &
+  { [K in keyof Required<T>]: extractType<T[K]> };
+
+type maybeExtractBox<T> = T extends Box<infer O, infer R> ? O : T;
+
+// prettier-ignore
+type extractOne<T extends mappedSchema> =
+/** Primitive types */
+  T extends primitiveType ? T :
 
     /** Holds the extracted type */
     T extends BoxAnySchema<infer O> ? maybeExtractBox<O> :
-    T extends BoxBooleanSchema<infer O> ? maybeExtractBox<O> :
-    T extends BoxStringSchema<infer O> ? maybeExtractBox<O> :
-    T extends BoxNumberSchema<infer O> ? maybeExtractBox<O> :
-    T extends BoxDateSchema<infer O> ? maybeExtractBox<O> :
-    T extends BoxFunctionSchema<infer O> ? maybeExtractBox<O> :
-    T extends BoxArraySchema<infer O> ? maybeExtractBox<O>[] :
-    T extends BoxObjectSchema<infer O> ? maybeExtractBox<O> :
-    T extends BoxAlternativesSchema<infer O> ? maybeExtractBox<O> :
+      T extends BoxBooleanSchema<infer O> ? maybeExtractBox<O> :
+        T extends BoxStringSchema<infer O> ? maybeExtractBox<O> :
+          T extends BoxNumberSchema<infer O> ? maybeExtractBox<O> :
+            T extends BoxDateSchema<infer O> ? maybeExtractBox<O> :
+              T extends BoxFunctionSchema<infer O> ? maybeExtractBox<O> :
+                T extends BoxArraySchema<infer O> ? maybeExtractBox<O>[] :
+                  T extends BoxObjectSchema<infer O> ? maybeExtractBox<O> :
+                    T extends BoxAlternativesSchema<infer O> ? maybeExtractBox<O> :
 
-    T extends AnySchema ? any :
-    any;
+                      T extends AnySchema ? any :
+                        any;
 
-  // prettier-ignore
-  export type extractType<T extends mappedSchema> =
-    /**
-     * Hack to support [Schema1, Schema2, ...N] alternatives notation
-     * Can't use extractType directly here because of cycles:
-     * ```
-     * T extends Array<infer O> ? extractType<O> :
-     *                            ^ cycle
-     * ```
-     */
-    T extends Array<infer O> ? (
+// prettier-ignore
+export type extractType<T extends mappedSchema> =
+/**
+ * Hack to support [Schema1, Schema2, ...N] alternatives notation
+ * Can't use extractType directly here because of cycles:
+ * ```
+ * T extends Array<infer O> ? extractType<O> :
+ *                            ^ cycle
+ * ```
+ */
+  T extends Array<infer O> ? (
       O extends SchemaLike ? extractOne<O> :
-      O extends BoxedPrimitive ? extractOne<O> :
-      O
-    ) :
+        O extends BoxedPrimitive ? extractOne<O> :
+          O
+      ) :
 
     /**
      * Handle Objects as schemas, without Joi.object at the root.
@@ -585,16 +688,15 @@ declare module JoiExtractType {
      */
     T extends mappedSchemaMap ? extractMap<T> :
 
-    /**
-     * This is the base case for every schema implemented
-     */
-    T extends SchemaLike ? extractOne<T> :
-    T extends BoxedPrimitive ? extractOne<T> :
+      /**
+       * This is the base case for every schema implemented
+       */
+      T extends SchemaLike ? extractOne<T> :
+        T extends BoxedPrimitive ? extractOne<T> :
 
-    /**
-     * Default case to handle primitives and schemas
-     */
-    extractOne<T>;
-}
+          /**
+           * Default case to handle primitives and schemas
+           */
+          extractOne<T>;
 
-export default JoiExtractType;
+export default extractType;

--- a/index.ts
+++ b/index.ts
@@ -1,13 +1,31 @@
-/** @format */
-
-import * as Joi from '@hapi/joi';
+import Joi, {
+  AlternativesSchema,
+  AnySchema,
+  ArraySchema,
+  BooleanSchema,
+  DateSchema,
+  Extension,
+  FunctionSchema,
+  NumberSchema,
+  ObjectSchema,
+  Reference,
+  Schema,
+  SchemaLike,
+  SchemaMap,
+  StringSchema,
+  ValidationError,
+  ValidationOptions,
+  ValidationResult,
+  WhenOptions,
+  WhenSchemaOptions,
+} from 'joi';
 
 /**
  * Helpers
  */
 type ArrayType<T> = T extends (infer U)[] ? U : never;
 
-declare module '@hapi/joi' {
+declare module JoiExtractType {
   /**
    * Allow extend() to use Joi types by default
    */
@@ -62,12 +80,12 @@ declare module '@hapi/joi' {
   export function validate<T, S extends mappedSchemaMap>(
     value: T,
     schema: S
-  ): ValidationResult<extendsGuard<T, extractType<S>>>;
+  ): ValidationResult;
   export function validate<T, S extends mappedSchemaMap>(
     value: T,
     schema: S,
     options: ValidationOptions
-  ): ValidationResult<extendsGuard<T, extractType<S>>>;
+  ): ValidationResult;
   export function validate<T, R, S extends mappedSchemaMap>(
     value: T,
     schema: S,
@@ -578,3 +596,5 @@ declare module '@hapi/joi' {
      */
     extractOne<T>;
 }
+
+export default JoiExtractType;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "joi-extract-type",
-  "version": "16.0.0",
+  "version": "17.0.0",
   "description": "Provides native type extraction from Joi schemas for Typescript",
   "main": "dist/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,11 +1,12 @@
 {
   "name": "joi-extract-type",
-  "version": "15.0.8",
+  "version": "16.0.0",
   "description": "Provides native type extraction from Joi schemas for Typescript",
   "main": "dist/index.js",
   "scripts": {
     "prepare": "rimraf dist && tsc",
-    "test": "tsc --build ./tsconfig.json"
+    "build": "tsc",
+    "test": "tsc --build ./tsconfig.spec.json"
   },
   "repository": {
     "type": "git",
@@ -24,14 +25,13 @@
   },
   "homepage": "https://github.com/TCMiranda/joi-extract-type#readme",
   "devDependencies": {
-    "typescript": "^3.9.6",
-    "rimraf": "^3.0.2"
+    "rimraf": "^3.0.2",
+    "typescript": "^3.9.6"
   },
   "peerDependencies": {
-    "@hapi/joi": "~15"
+    "joi": "^17.4.2"
   },
   "dependencies": {
-    "@hapi/joi": "~15",
-    "@types/hapi__joi": "~15"
+    "joi": "^17.4.2"
   }
 }

--- a/test.ts
+++ b/test.ts
@@ -1,9 +1,9 @@
 /** @format */
 
-import JoiExtractType from './index';
 import { jobOperatorRoleSchema } from './index.spec';
+import extractType from './index';
 
-export type expectedType = JoiExtractType.extractType<typeof jobOperatorRoleSchema>;
+export type expectedType = extractType<typeof jobOperatorRoleSchema>;
 
 export const response = ((unpredictableData: expectedType) => {
   const validation = unpredictableData.validate(jobOperatorRoleSchema);

--- a/test.ts
+++ b/test.ts
@@ -1,12 +1,12 @@
 /** @format */
 
-import * as Joi from 'joi';
+import JoiExtractType from './index';
 import { jobOperatorRoleSchema } from './index.spec';
 
-export type expectedType = Joi.extractType<typeof jobOperatorRoleSchema>;
+export type expectedType = JoiExtractType.extractType<typeof jobOperatorRoleSchema>;
 
 export const response = ((unpredictableData: expectedType) => {
-  const validation = Joi.validate(unpredictableData, jobOperatorRoleSchema);
+  const validation = unpredictableData.validate(jobOperatorRoleSchema);
 
   if (!validation.error) return validation.value;
 })(undefined);

--- a/tsconfig.spec.json
+++ b/tsconfig.spec.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": [
+    "node_modules",
+  ]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,51 +2,126 @@
 # yarn lockfile v1
 
 
-"@hapi/address@2.x.x":
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/@hapi/address/-/address-2.1.2.tgz#1c794cd6dbf2354d1eb1ef10e0303f573e1c7222"
-  integrity sha512-O4QDrx+JoGKZc6aN64L04vqa7e41tIiLU+OvKdcYaEMP97UttL0f9GIi9/0A4WAMx0uBd6SidDIhktZhgOcN8Q==
+"@hapi/hoek@^9.0.0":
+  version "9.2.1"
+  resolved "https://registry.yarnpkg.com/@hapi/hoek/-/hoek-9.2.1.tgz#9551142a1980503752536b5050fd99f4a7f13b17"
+  integrity sha512-gfta+H8aziZsm8pZa0vj04KO6biEiisppNgA1kbJvFrrWu9Vm7eaUEy76DIxsuTaWvti5fkJVhllWc6ZTE+Mdw==
 
-"@hapi/bourne@1.x.x":
-  version "1.3.2"
-  resolved "https://registry.yarnpkg.com/@hapi/bourne/-/bourne-1.3.2.tgz#0a7095adea067243ce3283e1b56b8a8f453b242a"
-  integrity sha512-1dVNHT76Uu5N3eJNTYcvxee+jzX4Z9lfciqRRHCU27ihbUcYi+iSc2iml5Ke1LXe1SyJCLA0+14Jh4tXJgOppA==
-
-"@hapi/hoek@8.x.x", "@hapi/hoek@^8.3.0":
-  version "8.5.0"
-  resolved "https://registry.yarnpkg.com/@hapi/hoek/-/hoek-8.5.0.tgz#2f9ce301c8898e1c3248b0a8564696b24d1a9a5a"
-  integrity sha512-7XYT10CZfPsH7j9F1Jmg1+d0ezOux2oM2GfArAzLwWe4mE2Dr3hVjsAL6+TFY49RRJlCdJDMw3nJsLFroTc8Kw==
-
-"@hapi/joi@~15":
-  version "15.1.1"
-  resolved "https://registry.yarnpkg.com/@hapi/joi/-/joi-15.1.1.tgz#c675b8a71296f02833f8d6d243b34c57b8ce19d7"
-  integrity sha512-entf8ZMOK8sc+8YfeOlM8pCfg3b5+WZIKBfUaaJT8UsjAAPjartzxIYm3TIbjvA4u+u++KbcXD38k682nVHDAQ==
+"@hapi/topo@^5.0.0":
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/@hapi/topo/-/topo-5.1.0.tgz#dc448e332c6c6e37a4dc02fd84ba8d44b9afb012"
+  integrity sha512-foQZKJig7Ob0BMAYBfcJk8d77QtOe7Wo4ox7ff1lQYoNNAb6jwcY1ncdoy2e9wQZzvNy7ODZCYJkK8kzmcAnAg==
   dependencies:
-    "@hapi/address" "2.x.x"
-    "@hapi/bourne" "1.x.x"
-    "@hapi/hoek" "8.x.x"
-    "@hapi/topo" "3.x.x"
+    "@hapi/hoek" "^9.0.0"
 
-"@hapi/topo@3.x.x":
-  version "3.1.6"
-  resolved "https://registry.yarnpkg.com/@hapi/topo/-/topo-3.1.6.tgz#68d935fa3eae7fdd5ab0d7f953f3205d8b2bfc29"
-  integrity sha512-tAag0jEcjwH+P2quUfipd7liWCNX2F8NvYjQp2wtInsZxnMlypdw0FtAOLxtvvkO+GSRRbmNi8m/5y42PQJYCQ==
+"@sideway/address@^4.1.0":
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/@sideway/address/-/address-4.1.2.tgz#811b84333a335739d3969cfc434736268170cad1"
+  integrity sha512-idTz8ibqWFrPU8kMirL0CoPH/A29XOzzAzpyN3zQ4kAWnzmNfFmRaoMNN6VI8ske5M73HZyhIaW4OuSFIdM4oA==
   dependencies:
-    "@hapi/hoek" "^8.3.0"
+    "@hapi/hoek" "^9.0.0"
 
-"@types/hapi__joi@*":
-  version "16.0.3"
-  resolved "https://registry.yarnpkg.com/@types/hapi__joi/-/hapi__joi-16.0.3.tgz#8ed6a0bd3a3fc40c0b5ff41b399004c5f9bb0b0b"
-  integrity sha512-gPxCfPcdZx9220GP4MFlhyBonQuyy8c/NZkGJkdtGipaExFzNLGYzkH2eG+yo0eEoVWdSC/JxhokSR/IHfap8Q==
+"@sideway/formula@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@sideway/formula/-/formula-3.0.0.tgz#fe158aee32e6bd5de85044be615bc08478a0a13c"
+  integrity sha512-vHe7wZ4NOXVfkoRb8T5otiENVlT7a3IAiw7H5M2+GO+9CDgcVUUsX1zalAztCmwyOr2RUTGJdgB+ZvSVqmdHmg==
 
-"@types/hapi__joi@~15":
-  version "15.0.4"
-  resolved "https://registry.yarnpkg.com/@types/hapi__joi/-/hapi__joi-15.0.4.tgz#49e2e1e6da15ade0fdd6db4daf94aecb07bb391b"
-  integrity sha512-VSS6zc7AIOdHVXmqKaGNPYl8eGrMvWi0R5pt3evJL3UdxO8XS28/XAkBXNyLQoymHxhMd4bF3o1U9mZkWDeN8w==
+"@sideway/pinpoint@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@sideway/pinpoint/-/pinpoint-2.0.0.tgz#cff8ffadc372ad29fd3f78277aeb29e632cc70df"
+  integrity sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ==
+
+balanced-match@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee"
+  integrity sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==
+
+brace-expansion@^1.1.7:
+  version "1.1.11"
+  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.11.tgz#3c7fcbf529d87226f3d2f52b966ff5271eb441dd"
+  integrity sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==
   dependencies:
-    "@types/hapi__joi" "*"
+    balanced-match "^1.0.0"
+    concat-map "0.0.1"
+
+concat-map@0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
+  integrity sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=
+
+fs.realpath@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
+  integrity sha1-FQStJSMVjKpA20onh8sBQRmU6k8=
+
+glob@^7.1.3:
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-7.2.0.tgz#d15535af7732e02e948f4c41628bd910293f6023"
+  integrity sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==
+  dependencies:
+    fs.realpath "^1.0.0"
+    inflight "^1.0.4"
+    inherits "2"
+    minimatch "^3.0.4"
+    once "^1.3.0"
+    path-is-absolute "^1.0.0"
+
+inflight@^1.0.4:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/inflight/-/inflight-1.0.6.tgz#49bd6331d7d02d0c09bc910a1075ba8165b56df9"
+  integrity sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=
+  dependencies:
+    once "^1.3.0"
+    wrappy "1"
+
+inherits@2:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
+  integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
+
+joi@^17.4.2:
+  version "17.4.2"
+  resolved "https://registry.yarnpkg.com/joi/-/joi-17.4.2.tgz#02f4eb5cf88e515e614830239379dcbbe28ce7f7"
+  integrity sha512-Lm56PP+n0+Z2A2rfRvsfWVDXGEWjXxatPopkQ8qQ5mxCEhwHG+Ettgg5o98FFaxilOxozoa14cFhrE/hOzh/Nw==
+  dependencies:
+    "@hapi/hoek" "^9.0.0"
+    "@hapi/topo" "^5.0.0"
+    "@sideway/address" "^4.1.0"
+    "@sideway/formula" "^3.0.0"
+    "@sideway/pinpoint" "^2.0.0"
+
+minimatch@^3.0.4:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
+  integrity sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==
+  dependencies:
+    brace-expansion "^1.1.7"
+
+once@^1.3.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/once/-/once-1.4.0.tgz#583b1aa775961d4b113ac17d9c50baef9dd76bd1"
+  integrity sha1-WDsap3WWHUsROsF9nFC6753Xa9E=
+  dependencies:
+    wrappy "1"
+
+path-is-absolute@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/path-is-absolute/-/path-is-absolute-1.0.1.tgz#174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f"
+  integrity sha1-F0uSaHNVNP+8es5r9TpanhtcX18=
+
+rimraf@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-3.0.2.tgz#f1a5402ba6220ad52cc1282bac1ae3aa49fd061a"
+  integrity sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==
+  dependencies:
+    glob "^7.1.3"
 
 typescript@^3.9.6:
   version "3.9.6"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.6.tgz#8f3e0198a34c3ae17091b35571d3afd31999365a"
   integrity sha512-Pspx3oKAPJtjNwE92YS05HQoY7z2SFyOpHo9MqJor3BXAGNaPUs83CuVp9VISFkSjyRfiTpmKuAYGJB7S7hOxw==
+
+wrappy@1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
+  integrity sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=


### PR DESCRIPTION
This PR addresses #44 by dropping support for the deprecated @hapi/joi library and providing support for sideway/joi instead. This is accomplished by providing a named module and setting it as the default export. Type signatures that have changed in sideway/joi have also been patched in this PR.

The new way to use this library would be:

```ts
import * as Joi from 'joi';
import JoiExtractType from 'joi-extract-type';
```

Create the schemas and use `extractType` to infer the type:

```ts
const is_enabled = Joi.boolean();
type extractBoolean = JoiExtractType.extractType<typeof is_enabled>;
export const extractedBoolean: extractBoolean = true;
```