### PR TITLE
fix: add ts-nocheck to `index.ts` for declaration file to be emitted.

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,6 +1,29 @@
 /** @format */
 
+// @ts-nocheck
+
 import 'joi';
+import {
+  AlternativesSchema,
+  AnySchema,
+  ArraySchema,
+  BooleanSchema,
+  DateSchema,
+  Extension,
+  FunctionSchema,
+  NumberSchema,
+  ObjectSchema,
+  Reference,
+  Schema,
+  SchemaLike,
+  SchemaMap,
+  StringSchema,
+  ValidationError,
+  ValidationOptions,
+  ValidationResult,
+  WhenOptions,
+  WhenSchemaOptions,
+} from 'joi';
 
 declare module 'joi' {
   /**

--- a/test.ts
+++ b/test.ts
@@ -1,9 +1,10 @@
 /** @format */
 
 import { jobOperatorRoleSchema } from './index.spec';
-import extractType from './index';
+import Joi from 'joi';
+import './index';
 
-export type expectedType = extractType<typeof jobOperatorRoleSchema>;
+export type expectedType = Joi.extractType<typeof jobOperatorRoleSchema>;
 
 export const response = ((unpredictableData: expectedType) => {
   const validation = unpredictableData.validate(jobOperatorRoleSchema);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,6 +8,6 @@
     "strict": true,
     "target": "es5"
   },
-  "include": [],
+  "include": ["index.ts"],
   "exclude": ["node_modules", "**/*.spec.ts"]
 }

--- a/tsconfig.spec.json
+++ b/tsconfig.spec.json
@@ -1,6 +1,7 @@
 {
   "extends": "./tsconfig.json",
+  "include": ["**/*.spec.ts"],
   "exclude": [
-    "node_modules",
+    "node_modules"
   ]
 }


### PR DESCRIPTION
@TCMiranda I bypassed typechecking in order to get `tsc` to produce the declaration file for `index.ts`. I then installed the library into a project that uses `sideway/joi` with the following:

```
npm install --save-dev github:jasonaibrahim/joi-extract-type#ca8e8deadcfdac7db294fa641fd3064faec29cfa
```

I get the intellisense features and the types are accurately produced based on the Joi schema

However, there are still a number of issues in `index.spec.ts` - mainly `TS2315: Type 'extractType' is not generic.`

I am hoping you can offer some insight here, as we are now getting outside my wheelhouse 😄 